### PR TITLE
Add run.dlang.io button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ d++ - #include C and C++ headers in D files
 ====================================================
 
 | [![Build Status](https://travis-ci.org/atilaneves/dpp.png?branch=master)](https://travis-ci.org/atilaneves/dpp) | [![Coverage](https://codecov.io/gh/atilaneves/dpp/branch/master/graph/badge.svg)](https://codecov.io/gh/atilaneves/dpp) |
-
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/JK0CAf)
 
 Goal
 ----


### PR DESCRIPTION
Just a simple, stupid button with the DPP Hello World, s.t. it's easier to find.

In theory we could support running also the examples with C code with har.
See: https://github.com/dlang-tour/core-exec/pull/40