### PR TITLE
add @nogc and nothrow to function aliases

### DIFF
--- a/source/dpp/translation/typedef_.d
+++ b/source/dpp/translation/typedef_.d
@@ -83,7 +83,7 @@ private string[] translateFunctionTypeDef(in from!"clang".Cursor typedef_,
     const returnTypeTransl = translate(returnType, context);
 
     const params = translateParamTypes(typedef_, context.indent).join(", ");
-    return [`alias ` ~ typedef_.spelling ~ ` = ` ~ returnTypeTransl ~ ` function(` ~ params ~ `);`];
+    return [`alias ` ~ typedef_.spelling ~ ` = ` ~ returnTypeTransl ~ ` function(` ~ params ~ `) @nogc nothrow;`];
 
 }
 


### PR DESCRIPTION
This fixed a problem of mine (vulkan.h), but I haven't tested it with any other code. As those aliases are for C function pointers I don't think this breaks anything else.