### PR TITLE
WIP: opaque types

### DIFF
--- a/examples/stl/app.dpp
+++ b/examples/stl/app.dpp
@@ -1,0 +1,82 @@
+struct DppBlob
+{
+	string typeName;
+}
+//#define Dlang
+#include "v.hpp"
+import std.stdio;
+void main()
+{
+	import std.range:iota;
+	import std.array:array;
+	import std.algorithm:map;
+	import std.conv:to;
+	auto values = iota(100).map!(v=>v.to!double).array;
+	auto v = problem(values.ptr,values.length);
+	/+auto size = getVectorSize!double(v.values.ptr);
+	auto bytes = getVectorDataDouble(v.values.ptr);
+	auto test = getVectorFoo(&v);
+	writeln(size);
+	writeln(test);
+	+/
+	auto results = getVector!double(v.values);
+	writeln(results);
+
+	auto values2 = iota(10).map!(v=>v.to!double*v.to!double).array;
+	auto v2 = Vector!(double,24)(values2);
+	writefln("v2.length = %s",v2.length);
+	//printVector!double(cast(void*)v2.getBlob());
+	writefln("v2.values= %s",v2.values);
+
+}
+
+struct Vector(T,size_t size)
+{
+	static Vector!(T,size) fromBlob(T,size_t size)(ubyte[size] blob)
+	{
+		Vector!(T,size) ret;
+		ret.values_ = blob;
+	}
+	this(T[] values)
+	{
+		createVector!T(this.values_.ptr,cast(void*)values.ptr,values.length);
+	}
+
+	T* ptr()
+	{
+		return cast(T*) getVectorData!T(values_.ptr);
+	}
+	size_t length()
+	{
+		return getVectorSize!T(this.values_.ptr);
+	}
+	T[] values()
+	{
+		return this.ptr()[0..this.length];
+	}
+
+	T opIndex(size_t index)
+	{
+		return this.values[index];
+	}
+
+	T[] opSlice(size_t start, size_t end)
+	{
+		return this.values[start..end];	
+	}
+
+	alias values this;
+	ubyte[] getBlob()
+	{
+		return this.values_;
+	}	
+	private ubyte[size] values_;
+}
+
+T[] getVector(T)(ubyte[] blob)
+{
+	auto size = getVectorSize!T(blob.ptr);
+	auto data = cast(double*)getVectorData!T(blob.ptr);
+	return data[0..size];
+}
+

--- a/examples/stl/app.dpp
+++ b/examples/stl/app.dpp
@@ -1,6 +1,9 @@
-struct DppBlob
+struct Opaque(string TypeName,size_t BlobSize)
 {
-	string typeName;
+	ubyte[BlobSize] blob;
+	alias blob this;
+	enum blobSize = BlobSize;
+	enum typeName = TypeName;
 }
 //#define Dlang
 #include "v.hpp"
@@ -28,14 +31,22 @@ void main()
 	//printVector!double(cast(void*)v2.getBlob());
 	writefln("v2.values= %s",v2.values);
 
+	auto v3 = vector(v.values);
+	writefln("v3.values = %s",v3.values);
 }
 
+alias VectorDouble = Opaque!("vector!(double)",24);
+auto vector(VectorDouble opaque)
+{
+	return Vector!(double,opaque.blobSize).fromBlob(opaque.blob);
+}
 struct Vector(T,size_t size)
 {
-	static Vector!(T,size) fromBlob(T,size_t size)(ubyte[size] blob)
+	static Vector!(T,size) fromBlob(ubyte[size] blob)
 	{
 		Vector!(T,size) ret;
 		ret.values_ = blob;
+		return ret;
 	}
 	this(T[] values)
 	{

--- a/examples/stl/app.dpp
+++ b/examples/stl/app.dpp
@@ -5,7 +5,6 @@ struct Opaque(string TypeName,size_t BlobSize)
 	enum blobSize = BlobSize;
 	enum typeName = TypeName;
 }
-//#define Dlang
 #include "v.hpp"
 import std.stdio;
 void main()
@@ -16,19 +15,12 @@ void main()
 	import std.conv:to;
 	auto values = iota(100).map!(v=>v.to!double).array;
 	auto v = problem(values.ptr,values.length);
-	/+auto size = getVectorSize!double(v.values.ptr);
-	auto bytes = getVectorDataDouble(v.values.ptr);
-	auto test = getVectorFoo(&v);
-	writeln(size);
-	writeln(test);
-	+/
 	auto results = getVector!double(v.values);
 	writeln(results);
 
 	auto values2 = iota(10).map!(v=>v.to!double*v.to!double).array;
 	auto v2 = Vector!(double,24)(values2);
 	writefln("v2.length = %s",v2.length);
-	//printVector!double(cast(void*)v2.getBlob());
 	writefln("v2.values= %s",v2.values);
 
 	auto v3 = vector(v.values);
@@ -87,7 +79,7 @@ struct Vector(T,size_t size)
 T[] getVector(T)(ubyte[] blob)
 {
 	auto size = getVectorSize!T(blob.ptr);
-	auto data = cast(double*)getVectorData!T(blob.ptr);
+	auto data = cast(T*)getVectorData!T(blob.ptr);
 	return data[0..size];
 }
 

--- a/examples/stl/build.sh
+++ b/examples/stl/build.sh
@@ -1,0 +1,2 @@
+clang++ -c v.cpp
+d++ --parse-as-cpp --c++-std-lib --keep-d-files app.dpp v.o 

--- a/examples/stl/dummy.cpp
+++ b/examples/stl/dummy.cpp
@@ -1,0 +1,7 @@
+#include "v.hpp"
+
+void dummy2_(void)
+{
+	getVectorSize<double>;
+	getVectorData<double>;
+}

--- a/examples/stl/test.cpp
+++ b/examples/stl/test.cpp
@@ -1,6 +1,0 @@
-#include <vector>
-
-void test(char* bytes)
-{
-	auto p = reinterpret_cast<std::vector<double>*>(&bytes);
-}

--- a/examples/stl/test.cpp
+++ b/examples/stl/test.cpp
@@ -1,0 +1,6 @@
+#include <vector>
+
+void test(char* bytes)
+{
+	auto p = reinterpret_cast<std::vector<double>*>(&bytes);
+}

--- a/examples/stl/v.cpp
+++ b/examples/stl/v.cpp
@@ -1,0 +1,32 @@
+#include <vector>
+#include <string>
+#include <map>
+#include "v.hpp"
+#include "stdio.h"
+
+using std::vector;
+using std::string;
+using std::map;
+using std::pair;
+
+double* getVectorDataDouble(void* bytes)
+{
+	auto size = getVectorSize<double>(bytes);
+	return (double*) getVectorData<double>(bytes);
+}
+
+
+Problem problem(double* values, size_t numValues)
+{
+	Problem ret;
+	for(ulong i=0;i<numValues;++i)
+		ret.values.push_back(values[i]);
+	printf("problem: %ld\n",numValues);
+	printf("problem values.back: %f\n",values[numValues-1]);
+	return ret;
+}
+
+size_t getVectorFoo(struct Problem* problem)
+{
+	return problem->values.size();
+}

--- a/examples/stl/v.hpp
+++ b/examples/stl/v.hpp
@@ -15,7 +15,7 @@ using std::pair;
 struct Problem
 {
 	vector<double> values;
-	//map<std::string,std::string> stringStringMap2;
+	map<std::string,std::string> stringStringMap2;
 	// MapStringString stringStringMap; typedef dont work yet
 	// PairStringString pairStringString;
 };

--- a/examples/stl/v.hpp
+++ b/examples/stl/v.hpp
@@ -1,0 +1,68 @@
+#include <vector>
+#include <string>
+#include <map>
+//#include <pair>
+#include "stdio.h"
+
+using std::vector;
+using std::string;
+using std::map;
+using std::pair;
+
+// typedef map<std::string,std::string> MapStringString;
+// typedef pair<std::string,std::string> PairStringString;
+
+struct Problem
+{
+	vector<double> values;
+	//map<std::string,std::string> stringStringMap2;
+	// MapStringString stringStringMap; typedef dont work yet
+	// PairStringString pairStringString;
+};
+
+Problem problem(double*,size_t);
+template <class T>
+size_t getVectorSize(void* bytes)
+{
+	printf("getVectorSize should be %ld\n",sizeof(vector<T>));
+	vector<T>* p;
+	void** bytesPtr = reinterpret_cast<void**>(bytes);
+	p = reinterpret_cast<vector<T>*>(bytesPtr);
+	auto size = p->size();
+	printf("getVectorSize returning %ld\n",size);
+	return size;
+}
+
+template <class T>
+void printVector(void* bytes)
+{
+	void** bytesPtr = reinterpret_cast<void**>(bytes);
+	vector<T>* p = reinterpret_cast<vector<T>*>(bytesPtr);
+	auto size = p->size();	
+	printf("vector size = %ld\n",size);
+	for(long i = 0;i<size;++i)
+		printf("%f",p->data()[i]);
+}
+template <class T>
+void* getVectorData(void* bytes)
+{
+	void** bytesPtr = reinterpret_cast<void**>(bytes);
+	vector<T>* p = reinterpret_cast<vector<T>*>(bytesPtr);
+	return (void*) p->data();
+}
+template <class T>
+void createVector(void* ptr, void* data, size_t size)
+{
+	void** bytesPtr = reinterpret_cast<void**>(ptr);
+	vector<T>* v = reinterpret_cast<vector<T>*>(bytesPtr);
+	T* refData = reinterpret_cast<T*>(data);
+	*v = vector<double>(size);
+	for(long i =0; i<size;i++)
+		v->assign(i,refData[i]);
+}
+double* getVectorDataDouble(void* bytes);
+size_t getVectorFoo(struct Problem* problem);
+void* p1 = (void*) &getVectorSize<double>;
+void* p2 = (void*) &getVectorData<double>;
+void* p3 = (void*) &createVector<double>;
+void* p4 = (void*) &printVector<double>;

--- a/examples/stl/v.hpp
+++ b/examples/stl/v.hpp
@@ -1,23 +1,16 @@
 #include <vector>
 #include <string>
 #include <map>
-//#include <pair>
 #include "stdio.h"
 
 using std::vector;
 using std::string;
 using std::map;
-using std::pair;
-
-// typedef map<std::string,std::string> MapStringString;
-// typedef pair<std::string,std::string> PairStringString;
 
 struct Problem
 {
 	vector<double> values;
 	map<std::string,std::string> stringStringMap2;
-	// MapStringString stringStringMap; typedef dont work yet
-	// PairStringString pairStringString;
 };
 
 Problem problem(double*,size_t);

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -86,6 +86,31 @@ struct Context {
      */
     private SeenCursors seenCursors;
 
+    string[] blobTypes = ["vector","map","string","pair"];
+    string[] blackListedPaths = ["vector","string","map"];
+
+    bool isTypeBlobSubstituted(string typeName)
+    {
+	    import std.algorithm:canFind;
+	    foreach(blobType;blobTypes)
+	    {
+		import std.stdio:writefln,stderr;
+	    	debug stderr.writefln("// typename %s: blob %s",typeName,typeName.canFind(blobType));
+		if (typeName.canFind(blobType))
+			return true;
+	    }
+	    return false;
+    }
+    bool isPathBlackListed(string path) @safe pure
+    {
+	    import std.algorithm:canFind;
+	    foreach(blackListedPath;blackListedPaths)
+	    {
+		    if(path.canFind(blackListedPath) || path.canFind("c++"))
+			    return true;
+	    }
+	    return false;
+    }
     /// Command-line options
     Options options;
 

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -306,8 +306,8 @@ string[] translateField(in from!"clang".Cursor field,
 
     // Remember the field name in case it ends up clashing with a type.
     context.rememberField(field.spelling);
-
-    const type = translate(field.type, context, No.translatingFunction);
+    auto maybeRenamedFieldType = maybeRenameType(field,context).type;
+    const type = translate(maybeRenamedFieldType, context, No.translatingFunction);
 
     return field.isBitField
         ? translateBitField(field, context, type)
@@ -540,3 +540,48 @@ do
         `alias ` ~ fieldName ~ ` this;`,
     ];
 }
+
+string renameTypeToBlob(string spelling, size_t size)
+{
+	import std.format:format;
+	return format!`@DppBlob("%s") ubyte[%s]`(spelling,size);
+}
+
+from!"clang".Type maybeRenameTypeToBlob(const from!"clang".Type type, in from!"clang".Cursor cursor,
+                       ref from!"dpp.runtime.context".Context context) @trusted
+//    in(cursor.kind == from!"clang".Cursor.Kind.CXXBaseSpecifier)
+{
+	import clang:Cursor,Type;
+	import std.traits:Unqual;
+	auto ret = cast(Unqual!Type) type;
+	ret.spelling = context.isTypeBlobSubstituted(type.spelling) ? 
+			renameTypeToBlob(type.spelling,getSizeOf(type)) :
+			type.spelling;
+	return cast(Type) ret;
+}
+private auto getSizeOf(const from!"clang".Type type) pure
+{
+	import clang.c.index:clang_Type_getSizeOf;
+	return clang_Type_getSizeOf(type.cx);
+}
+
+private auto mutableCursor(const from!"clang".Cursor cursor) @trusted
+{
+	import std.traits:Unqual;
+	auto ret = cast(Unqual!(from!"clang".Cursor)) cursor;
+	return ret;
+}
+
+from!"clang".Cursor maybeRenameType(in from!"clang".Cursor cursor,
+                       ref from!"dpp.runtime.context".Context context) @safe
+//    in(cursor.kind == from!"clang".Cursor.Kind.CXXBaseSpecifier)
+{
+	import clang:Cursor,Type;
+	import std.stdio:writefln;
+
+	auto ret = mutableCursor(cursor);
+	debug writefln("// %s",cursor.type.spelling);
+	ret.type= maybeRenameTypeToBlob(ret.type,cursor,context);
+	return cast(Cursor)ret;
+}
+

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -544,7 +544,7 @@ do
 string renameTypeToBlob(string spelling, size_t size)
 {
 	import std.format:format;
-	return format!`@DppBlob("%s") ubyte[%s]`(spelling,size);
+	return format!`Opaque!("%s",%s)`(spelling,size);
 }
 
 from!"clang".Type maybeRenameTypeToBlob(const from!"clang".Type type, in from!"clang".Cursor cursor,

--- a/source/dpp/translation/translation.d
+++ b/source/dpp/translation/translation.d
@@ -20,12 +20,13 @@ string translateTopLevelCursor(in from!"clang".Cursor cursor,
     import std.array: join;
     import std.algorithm: map;
 
-    return cursor.skipTopLevel
+    return cursor.skipTopLevel(context)
         ? ""
         : translate(cursor, context, file, line).map!(a => "    " ~ a).join("\n");
 }
 
-private bool skipTopLevel(in from!"clang".Cursor cursor) @safe pure {
+private bool skipTopLevel(in from!"clang".Cursor cursor,
+			ref from!"dpp.runtime.context".Context context) @safe pure {
     import dpp.translation.aggregate: isAggregateC;
     import clang: Cursor;
     import std.algorithm: startsWith, canFind;
@@ -34,6 +35,17 @@ private bool skipTopLevel(in from!"clang".Cursor cursor) @safe pure {
     if(cursor.spelling == "" && cursor.kind == Cursor.Kind.EnumDecl)
         return false;
 
+    if(context.isPathBlackListed(cursor.sourceRange.path))
+    {
+	    import std.stdio;
+	    //debug writeln("skipping %s",cursor.sourceRange);
+	    return true;
+    }
+    else
+    {
+	    import std.stdio;
+	    //debug writeln("not skipping %s",cursor.sourceRange);
+    }
     // don't bother translating top-level anonymous aggregates
     if(isAggregateC(cursor) && cursor.spelling == "")
         return true;
@@ -63,6 +75,12 @@ string[] translate(in from!"clang".Cursor cursor,
     import std.conv: text;
     import std.algorithm: canFind;
 
+    if(context.isPathBlackListed(cursor.sourceRange.path))
+    {
+	    import std.stdio;
+	    //debug writeln("skipping %s",cursor.sourceRange);
+	    return [];
+    }
     debugCursor(cursor, context);
 
     if(context.language == Language.Cpp && ignoredCppCursorSpellings.canFind(cursor.spelling)) {

--- a/source/dpp/translation/typedef_.d
+++ b/source/dpp/translation/typedef_.d
@@ -10,8 +10,8 @@ string[] translateTypedef(in from!"clang".Cursor typedef_,
     @safe
 {
     import dpp.translation.type: translate, isTypeParameter;
-    import dpp.translation.aggregate: isAggregateC;
-    import dpp.translation.dlang: maybeRename;
+    import dpp.translation.aggregate: isAggregateC,maybeRenameTypeToBlob;
+    import dpp.translation.dlang:maybeRename;
     import clang: Cursor, Type;
     import std.conv: text;
     import std.typecons: No;
@@ -26,7 +26,7 @@ string[] translateTypedef(in from!"clang".Cursor typedef_,
         .array;
     }();
 
-    const nonCanonicalUnderlyingType = typedef_.underlyingType;
+    const nonCanonicalUnderlyingType = maybeRenameTypeToBlob(typedef_.underlyingType,typedef_,context);
     const canonicalUnderlyingType = nonCanonicalUnderlyingType.canonical;
 
     context.log("Children: ", children);

--- a/source/main.d
+++ b/source/main.d
@@ -9,7 +9,7 @@ int main(string[] args) {
         run(options);
         return 0;
     } catch(Exception ex) {
-        stderr.writeln("Error: ", ex.msg);
+        stderr.writeln(ex);
         return 1;
     } catch(Throwable t) {
         stderr.writeln("Fatal error: ", t);


### PR DESCRIPTION
Implementation is very hackish because I was in a hurry and I also don't really know C++.

This adds the ability to blacklist file paths to be translated by dpp and to blacklist types.  Blacklisted types will be substituted in the translated D code by Opaque!("NameOfType",SizeOfType).  

In examples/stl-opaque there is a script build.sh.  This will build a little demonstration from v.hpp, v.cpp and app.dpp showing that one can successfully wrap a source header including a definition of a type depending on std::vector and then access the underlying data as you would expect.

Where dpp replaces instantiated versions of STL types like Opaque!("vector!(double)",24) then dpp should track these and generate boilerplate like double[] getVector(Opaque!("vector!(double)",24) v) and create any instantiation boilerplate that might be needed in C++.