### PR TITLE
Windows support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,14 @@ Becomes:
 pragma(mangle, "debug")
 void debug_(const(char)*);
 ```
+
+
+Build Instructions
+------------------
+
+### Windows
+
+1. Install http://releases.llvm.org/6.0.1/LLVM-6.0.1-win64.exe into `C:\Program Files\LLVM\`, making sure to tick the "Add LLVM to the system PATH for all users" option.
+2. Make sure you have [LDC](https://github.com/ldc-developers/ldc/releases) installed somewhere.
+3. Compile with `dub build --compiler=C:\path\to\bin\ldc2.exe`.
+4. Copy `C:\Program Files\LLVM\bin\libclang.dll` next to the `d++.exe` in the `bin` directory.

--- a/dub.sdl
+++ b/dub.sdl
@@ -8,7 +8,7 @@ targetType "executable"
 targetPath "bin"
 targetName "d++"
 dflags "-dip25"
-lflags "-L/usr/lib/llvm-6.0/lib"  # for Travis CI
+lflags "-L/usr/lib/llvm-6.0/lib" platform="posix" # for Travis CI
 
 dependency "libclang" version="~>0.1.1"
 dependency "sumtype"  version="~>0.7.1"

--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -216,8 +216,25 @@ private void runCPreProcessor(in string tmpFileName, in string outputFileName) @
     import std.stdio: File;
     import std.algorithm: filter, startsWith;
 
-    const cppArgs = ["cpp", tmpFileName];
-    const ret = execute(cppArgs);
+    version (Windows)
+    {
+        enum cpp = "clang-cpp";
+    } else {
+        enum cpp = "cpp";
+    }
+
+    const cppArgs = [cpp, tmpFileName];
+    const ret = () {
+        try
+        {
+            return execute(cppArgs);
+        }
+        catch (Exception e)
+        {
+            import std.typecons : Tuple;
+            return Tuple!(int, "status", string, "output")(-1, e.msg);
+        }
+    }();
     enforce(ret.status == 0, text("Could not run `", cppArgs.join(" "), "`:\n", ret.output));
 
     {


### PR DESCRIPTION
Fixes issues #80 and #86.

Just a trivial `dub` change and build instructions. The real change is in `libclang`, so please bump its version and update dub dependencies.

Cheers,
Bastiaan.