### PR TITLE
[MINOR] Fix for warning in mockTU

### DIFF
--- a/tests/contract/package.d
+++ b/tests/contract/package.d
@@ -324,7 +324,7 @@ struct Module {
  */
 auto mockTU(Module moduleName, CodeURL codeURL)() {
 
-    mixin(`import `, moduleName.name, `;`);
+    mixin(`import ` ~ moduleName.name ~ `;`);
     import std.meta: Alias, AliasSeq, Filter, staticMap;
     import std.traits: hasUDA, getUDAs;
     import std.algorithm: startsWith;


### PR DESCRIPTION
Running:
CC=clang-8 CXX=clang++-8 dub test --compiler=/usr/bin/ldc2
I get
```
dpp 0.1.17+commit.2.g1afa31b: building configuration "unittest"...
tests/contract/package.d(327,20): Error: found , when expecting )
tests/contract/package.d(327,22): Error: found moduleName when expecting ;
tests/contract/package.d(327,42): Error: found ) when expecting ; following statement
tests/contract/package.d(327,43): Deprecation: use { } for an empty statement, not ;
/usr/bin/ldc2 failed with exit code 1.
```