### PR TITLE
Fix issue 168 Macro's using `(__extension__({}))`

### DIFF
--- a/source/dpp/translation/translation.d
+++ b/source/dpp/translation/translation.d
@@ -257,7 +257,6 @@ bool untranslatable(in string line) @safe pure {
         || line.canFind("variant!")
         || line.canFind("value _ ")
         || line.canFind("enable_if_c")
-        || line.canFind(`}))`)  // ???
         || line.canFind(`(this_)_M_t._M_equal_range_tr(`)
         || line.canFind(`this-`)
         || line.canFind("_BoundArgs...")

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -1533,3 +1533,23 @@ unittest {
         ),
    );
 }
+
+@Tags("issue")
+@("168")
+// @("gcc.__extention__")
+// Examples:
+//    /usr/include/netinet/in.h
+//    /usr/include/x86_64-linux-gnu/bits/cpu-set.h
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                #define FOO(bar) {__extension__({bar;})
+            `
+        ),
+        D(
+            q{
+            }
+        )
+    );
+}


### PR DESCRIPTION
Includes a test for the issue and a simple 'fix'. Not sure if the fix is the way you would like to go though.
references #168
fixes #168