### PR TITLE
Modifications to make `dub test` pass on Windows

### DIFF
--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -100,7 +100,12 @@ private bool ignoreFunction(in from!"clang".Cursor cursor) @safe {
     // The lexical parent only differs from the semantic parent
     // in this case.
     if(
-        cursor.kind == Cursor.Kind.CXXMethod
+        // the constructor type is for issue 115 test on Windows. 
+        // it didn't trigger the check above because the CompoundStmts
+        // are not present on the Windows builds of libclang for
+        // template member functions (reason unknown)
+        // but this check appears to do the right thing anyway.
+        (cursor.kind == Cursor.Kind.CXXMethod || cursor.kind == Cursor.Kind.Constructor)
         && cursor.semanticParent != cursor.lexicalParent
     )
         return true;

--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -126,6 +126,7 @@ private string fixLiteral(in from!"clang".Token token)
 {
     return token.spelling
         .fixOctal
+	.fixMicrosoftSuffixes
         .fixLongLong
         ;
 }
@@ -171,6 +172,24 @@ private const(from!"clang".Token)[] fixNull(
         .array;
 }
 
+version(Windows)
+private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
+    import std.algorithm: endsWith;
+
+    if(str.endsWith("i64"))
+        return str[0 .. $-3] ~ "L";
+    else if(str.endsWith("i32"))
+        return str[0 .. $-3];
+    else if(str.endsWith("i16"))
+        return str[0 .. $-3];
+    else if(str.endsWith("i8"))
+        return str[0 .. $-3];
+    return str;
+}
+else
+private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
+    return str;
+}
 
 
 private string fixLongLong(in string str) @safe pure nothrow {

--- a/tests/contract/templates.d
+++ b/tests/contract/templates.d
@@ -373,7 +373,11 @@ import contract;
     printChildren(ctor);
     ctor.kind.should == Cursor.Kind.Constructor;
 
-    ctor.children.length.should == 2;
+    version(Windows)
+        ctor.children.length.should == 1; // Windows llvm ast doesn't include the body...
+    else
+        ctor.children.length.should == 2;
+
     const ctorParam = ctor.children[0];
     ctorParam.kind.should == Cursor.Kind.ParmDecl;
     ctorParam.type.kind.should == Type.Kind.LValueReference;
@@ -426,7 +430,10 @@ import contract;
     ctor.semanticParent.templateParams.length.should == 1;  // the `T`
     ctor.semanticParent.templateParams[0].spelling.should == "T";
 
-    ctor.children.length.should == 2;
+    version(Windows)
+        ctor.children.length.should == 1; // Windows llvm ast doesn't include the body...
+    else
+        ctor.children.length.should == 2;
     const ctorParam = ctor.children[0];
     ctorParam.kind.should == Cursor.Kind.ParmDecl;
     ctorParam.type.kind.should == Type.Kind.LValueReference;

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -5,6 +5,7 @@ module it.issues;
 
 import it;
 
+version(Posix) // because Windows doesn't have signinfo
 @Tags("issue")
 @("3")
 @safe unittest {
@@ -737,6 +738,7 @@ import it;
 }
 
 
+version(linux) // linux specific header in the test
 @Tags("issue")
 @("66")
 @safe unittest {
@@ -1038,11 +1040,18 @@ unittest {
 @Tags("issue")
 @("101")
 @safe unittest {
+    // SO tells me the standard insists upon unsigned long long
+    // and apparently so does MSVC... but linux doesn't. idk why.
+    // see: https://stackoverflow.com/a/16596909/1457000
+    version(Windows)
+        string type = "unsigned long long";
+    else
+        string type = "unsigned long";
     shouldCompile(
         Cpp(
             q{
                 // normally without the underscore
-                int operator "" _s(const wchar_t* __str, unsigned long __len);
+                int operator "" _s(const wchar_t* __str, } ~ type ~ q{ __len);
             }
         ),
         D(


### PR DESCRIPTION
Note it will also require new unit-threaded and libclang
to fully pass.

In a couple cases, I exempted the test since it was not
applicable on the Windows platform, but for the most part,
it was tweaking platform-specific details like object file
name extensions and hacking around a slower filesystem.

The MS headers use literals in the form of, e.g. 255i8, and
that extension needed to be handled as well. Otherwise, fairly
small overall.


I realize some of these are unprincipled hacks, so lemme know if you have better ideas...