### PR TITLE
Fix bug when a multiline macro could cause a range violation error

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -342,7 +342,8 @@ private const(from!"clang".Token)[] fixCasts(
             while(open != 0) {
                 if(tokens[scanIndex] == Token(Token.Kind.Punctuation, "("))
                     ++open;
-                if(tokens[scanIndex] == Token(Token.Kind.Punctuation, ")"))
+                if(tokens[scanIndex] == Token(Token.Kind.Punctuation, ")")
+                        || tokens[scanIndex] == Token(Token.Kind.Punctuation, "\\\n)"))
                     --open;
 
                 ++scanIndex;


### PR DESCRIPTION
Encountered this while trying to use d++ on a .dpp file containing the following C macro from linux/kernel.h:
```c
#define u64_to_user_ptr(x) ( \
{ \
	typecheck(u64, x); \
	(void __user *)(uintptr_t)x; \
} \					
)
```
The issue is that the token spelling is not just ")" for the last closed paren, but "\\" + new line + ")", and we would increase the scanIndex indefinitely, searching for just a ")" token.

This fixes the preprocessing part, where dpp would crash because of a fatal error. Still, compilation of the generated D file might fail in some cases, as the macro expansion could generate invalid D code (even if in C it would be valid).