### PR TITLE
Handle rare multi-character literals and Microsoft

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -127,7 +127,7 @@ private string fixLiteral(in from!"clang".Token token)
     return token.spelling
         .fixMultiCharacterLiterals
         .fixOctal
-	.fixMicrosoftSuffixes
+        .fixMicrosoftSuffixes
         .fixLongLong
         ;
 }

--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -125,6 +125,7 @@ private string fixLiteral(in from!"clang".Token token)
     do
 {
     return token.spelling
+        .fixMultiCharacterLiterals
         .fixOctal
 	.fixMicrosoftSuffixes
         .fixLongLong
@@ -189,6 +190,29 @@ private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
 else
 private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
     return str;
+}
+
+private string fixMultiCharacterLiterals(in string str) @safe pure nothrow {
+    // multi-character literals are implementation-defined, but allowed,
+    // in C I aim to identify them and then distinguish them from a
+    // non-ASCII character, which I'll just forward to D assuming utf-8 source
+    // moreover, the '\uxxx' or other escape sequences should be forwarded
+    if(str.length > 3 && str[0] == '\'' && str[$-1] == '\'' && str[1] != '\\') {
+        // apparently a multi-char literal, let's translate to int
+        // the way this is typically done in common compilers, e.g.
+        // https://gcc.gnu.org/onlinedocs/cpp/Implementation-defined-behavior.html 
+        int result;
+        foreach(char ch; str[1 .. $-1]) {
+            // any multi-byte character I'm going to assume
+            // is just a single UTF-8 char and punt on it.
+            if(ch > 127) return str;
+            result <<= 8;
+            result |= cast(ubyte) ch;
+        }
+        import std.conv;
+        return to!string(result);
+    }
+    return str; // not one of these, don't touch
 }
 
 

--- a/source/dpp/translation/type/package.d
+++ b/source/dpp/translation/type/package.d
@@ -325,10 +325,20 @@ private string translatePointer(in from!"clang".Type type,
         return true;
     }
 
-    const ptrType = addConst
-        ? `const(` ~ rawType ~ maybeStar ~ `)`
-        : rawType ~ maybeStar;
+    version(Windows) {
+        // Microsoft extension for pointers that doesn't compile
+        // elsewhere. It tells the pointer may point to an unaligned
+        // structure, for platforms where that is an optimization. Just
+        // ignoring so it works here.
+        import std.string;
+        auto typePart = replace(rawType, "__unaligned ", "");
+    } else {
+        auto typePart = rawType;
+   }
 
+    const ptrType = addConst
+        ? `const(` ~ typePart ~ maybeStar ~ `)`
+        : typePart ~ maybeStar;
     return ptrType;
 }
 

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -5,6 +5,23 @@ module it.c.compile.projects;
 
 import it;
 
+@("multicharacter_literal")
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                #define test 'ABCD'
+            `
+        ),
+
+        D(
+            q{
+                static assert(test == 1094861636); // determined by printf("%d\n", 'ABCD'); in C
+            }
+        )
+    );
+}
+
 @("nn_get_statistic")
 @safe unittest {
     shouldCompile(


### PR DESCRIPTION
pointer extensions seen in the Windows API headers.