### PR TITLE
Fix bug where typeof would be called with actual types and not expressions

### DIFF
--- a/source/dpp/translation/type/package.d
+++ b/source/dpp/translation/type/package.d
@@ -434,9 +434,23 @@ private string translateUnexposed(in from!"clang".Type type,
     const translation =  translateString(spelling, context)
         // we might get template arguments here (e.g. `type-parameter-0-0`)
         .replace("type-parameter-0-", "type_parameter_0_")
+        .maybeTranslateTypeof()
         ;
 
     return addModifiers(type, translation);
+}
+
+string maybeTranslateTypeof(in string spelling)
+    @safe nothrow
+{
+    import std.algorithm : startsWith;
+    import std.string: replace;
+    const typeofStr = "typeof";
+
+    if (!startsWith(spelling, typeofStr))
+        return spelling;
+
+    return typeofStr ~ "(" ~ spelling[typeofStr.length .. $].replace("struct ", "") ~ ".init)";
 }
 
 /**

--- a/tests/it/c/compile/typeof_.d
+++ b/tests/it/c/compile/typeof_.d
@@ -1,0 +1,24 @@
+module it.c.compile.typeof_;
+
+
+import it;
+
+
+@("typeof with actual types")
+@C(
+    q{
+        struct Foo;
+        typeof(struct Foo *) f();
+    }
+)
+@safe unittest {
+    mixin(
+        shouldCompile(
+            D(
+                q{
+                }
+            )
+        )
+    );
+}
+

--- a/tests/it/main.d
+++ b/tests/it/main.d
@@ -16,6 +16,7 @@ mixin runTestsMain!(
     "it.c.compile.projects",
     "it.c.compile.runtime_args",
     "it.c.compile.collision",
+    "it.c.compile.typeof_",
     "it.c.run.struct_",
     "it.c.run.c",
 

--- a/tests/test_main.d
+++ b/tests/test_main.d
@@ -57,6 +57,7 @@ version(dpp2) {
         "it.c.compile.projects",
         "it.c.compile.runtime_args",
         "it.c.compile.collision",
+        "it.c.compile.typeof_",
         "it.c.run.struct_",
         "it.c.run.c",
 


### PR DESCRIPTION
Previously:
```d
// C code => D code
struct Task;
int a;
typeof(int) => typeof(int) // err
typeof(struct Task *) => typeof(struct Task *) // err
typeof(a) => typeof(a) // ok
```

The solution does the following:

```d
typeof(int) => typeof((int).init) // ok
typeof(struct Task *) => typeof((Task *).init) // ok
typeof(a) => typeof((a).init) // ok
```