### PR TITLE
Handle nested C11 anonymous structs/unions

### DIFF
--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -422,6 +422,39 @@ version(Posix) // because Windows doesn't have signinfo
     );
 }
 
+@Tags("issue")
+@("29.4")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct Struct {
+                    union {
+                        int a;
+                        struct {
+                            int b;
+                            union {
+                                int c;
+                                char d;
+                            };
+                        };
+                    };
+                };
+            }
+        ),
+        D(
+            q{
+                Struct s;
+                s.a = 42;
+                s.b = 1337;
+                s.c = 7;
+                s.d = 'D';
+            }
+        ),
+    );
+}
+
+
 
 @Tags("issue")
 @("33.0")


### PR DESCRIPTION
An example of this bug is shown [here](https://gist.github.com/cbecerescu/9a114bb92b23bd8e275a8eae08c6cc2f). (the issue being the last two accessors in the translated D code).

My understanding is that, previously, we would only go to the sub-sub members of a given anonymous struct or union. But if the nesting level is deeper than that, then we no longer generate the accessors correctly for the deeper levels.