### PR TITLE
Context uses Appender for performance reasons

### DIFF
--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -152,7 +152,7 @@ struct Context {
        Writes a line of translation.
      */
     void writeln(in string line) @safe pure nothrow {
-        lines ~= line.dup;
+        lines ~= line;
     }
 
     /**

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -29,7 +29,7 @@ struct Context {
     alias SeenCursors = bool[CursorId];
 
     private auto lines(this This)() {
-        return _lines[];
+        return _lines.data;
     }
 
     /**

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -24,15 +24,20 @@ struct Context {
 
     import dpp.runtime.options: Options;
     import clang: Cursor, Type, AccessSpecifier;
+    import std.array: Appender;
 
     alias SeenCursors = bool[CursorId];
+
+    private auto lines(this This)() {
+        return _lines[];
+    }
 
     /**
        The lines of output so far. This is needed in order to fix
        any name collisions between functions or variables with aggregates
        such as structs, unions and enums.
      */
-    private string[] lines;
+    private Appender!(string[]) _lines;
 
     /**
        Structs can be anonymous in C, and it's even common
@@ -152,14 +157,14 @@ struct Context {
        Writes a line of translation.
      */
     void writeln(in string line) @safe pure nothrow {
-        lines ~= line;
+        _lines ~= line;
     }
 
     /**
        Writes lines of translation.
     */
     void writeln(in string[] lines) @safe pure nothrow {
-        this.lines ~= lines;
+        _lines ~= lines;
     }
 
     // remember a function or variable declaration

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -148,10 +148,16 @@ struct Context {
         return lines.join("\n");
     }
 
+    /**
+       Writes a line of translation.
+     */
     void writeln(in string line) @safe pure nothrow {
         lines ~= line.dup;
     }
 
+    /**
+       Writes lines of translation.
+    */
     void writeln(in string[] lines) @safe pure nothrow {
         this.lines ~= lines;
     }


### PR DESCRIPTION
Use std.array.Appender instead of a raw dynamic array for "writing" out the translations.