### PR TITLE
Accessors for members of anonymous records are renamed when the members are keywords

### DIFF
--- a/tests/it/c/compile/collision.d
+++ b/tests/it/c/compile/collision.d
@@ -188,3 +188,28 @@ import it;
         ),
     );
 }
+
+@Tags("collision")
+@("Accessors for members of anonymous records are renamed")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct A {
+                    union {
+                        unsigned int version;
+                        char module;
+                    };
+                    int a;
+                };
+            }
+        ),
+        D(
+            q{
+                A a;
+                a.version_ = 7;
+                a.module_ = 'D';
+            }
+        ),
+    );
+}


### PR DESCRIPTION
Previously, in a case like the one below
```c
struct A {
    union {
        unsigned int version;
        char module;
    };
};
```

the members themselves would be renamed (to version_ and module_), but the accessor function names would not (they would be auto version(...) and auto module(...)).