### PR TITLE
Made fixFields work better for C11 anon records and deal with multiple structs using the same field name which needs renaming

### DIFF
--- a/tests/it/c/compile/collision.d
+++ b/tests/it/c/compile/collision.d
@@ -213,3 +213,32 @@ import it;
         ),
     );
 }
+
+@Tags("collision")
+@("Members (pointers to struct) in multiple structures")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct A;
+
+                struct B {
+                    struct A *A;
+                };
+
+                struct C {
+                    struct A* A;
+                };
+            }
+        ),
+        D(
+            q{
+                A *a;
+                B b;
+                b.A_ = a;
+                C c;
+                c.A_ = a;
+            }
+        ),
+    );
+}

--- a/tests/it/c/compile/collision.d
+++ b/tests/it/c/compile/collision.d
@@ -215,7 +215,7 @@ import it;
 }
 
 @Tags("collision")
-@("Members (pointers to struct) in multiple structures")
+@("Members (pointers to struct) in multiple (possibly anon) structures")
 @safe unittest {
     shouldCompile(
         C(
@@ -229,6 +229,13 @@ import it;
                 struct C {
                     struct A* A;
                 };
+
+                struct D {
+                    union {
+                        struct A* A;
+                        int d;
+                    };
+                };
             }
         ),
         D(
@@ -238,6 +245,8 @@ import it;
                 b.A_ = a;
                 C c;
                 c.A_ = a;
+                D d;
+                d.A_ = a;
             }
         ),
     );


### PR DESCRIPTION
Previously, for this case
```c
struct A;
struct B {
    struct A* A;
};

struct C {
    struct A* A;
};
```
dpp would only rename one of the fields (either the one in B or in C), because the _fieldDeclarations associative array overwrites the already existing (if any) line number with a new one. So it would rename only the field which is contained in the last processed struct.

My solution is changing the value of the associative array from LineNumber to LineNumber[], so that dpp knows of all instances where the field should be renamed.

Also made fixFields correctly rename the accessor functions' name and the field that the accessor functions try to access.