### PR TITLE
Don't generate accessor functions when declaring a const anonymous struct as a field

### DIFF
--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -513,6 +513,12 @@ private string[] maybeC11AnonymousRecords(in from!"clang".Cursor cursor,
         const isField =
             child.kind == Cursor.Kind.FieldDecl &&
             (child.type.canonical == member.type.canonical ||
+                // If the inner struct declaration is 'const struct {...} X;',
+                // then child.type.canonical would be:
+                // Type(Elaborated, "const struct (anonymous struct at fileY)"),
+                // and member.type.canonical would be:
+                // Type(Record, "struct ParentStruct::(anonymous at fileY)").
+                // This is the reason why we unelaborate the child.type.
                 child.type.unelaborate == member.type.canonical);
 
         const isArrayOf = child.type.elementType.canonical == member.type.canonical;

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -512,7 +512,8 @@ private string[] maybeC11AnonymousRecords(in from!"clang".Cursor cursor,
     static bool isFieldOfRightType(in Cursor member, in Cursor child) {
         const isField =
             child.kind == Cursor.Kind.FieldDecl &&
-            child.type.canonical == member.type.canonical;
+            (child.type.canonical == member.type.canonical ||
+                child.type.unelaborate == member.type.canonical);
 
         const isArrayOf = child.type.elementType.canonical == member.type.canonical;
         return isField || isArrayOf;

--- a/tests/it/c/compile/struct_.d
+++ b/tests/it/c/compile/struct_.d
@@ -300,3 +300,24 @@ import it;
         )
     );
 }
+
+@("const anonymous struct as field")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct A {
+                    const struct {
+                        int version;
+                        int other;
+                    } version;
+                };
+            }
+        ),
+        D(
+            q{
+                A a = { version_ : { version_ : 13, other : 7 } };
+            }
+        )
+    );
+}


### PR DESCRIPTION
Previously, for this code
```c
struct A {
    const struct {
        int version;
        int other;
    } version;
};
```

dpp would declare a 'const(\_Anonymous_0) version\_;' field inside struct A, along with accessors for the \_Anonymous\_0 struct (i.e. auto version_()). This would result in name clashes. But, anyway, there is no need to define accessors as we already have a named field through which we can modify (in this case just at initialization, because of the const) the field of type \_Anonymous\_0.