### PR TITLE
Change EnumBaseType if the enum values overflow int

### DIFF
--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -182,7 +182,8 @@ string[] translateAggregate(
         ? "static " ~ dKeyword
         : dKeyword;
     const parents = maybeParents(cursor, context, dKeyword);
-    const firstLine = realDlangKeyword ~ ` ` ~ name ~ parents;
+    const enumBaseType = maybeEnumBaseType(cursor, dKeyword);
+    const firstLine = realDlangKeyword ~ ` ` ~ name ~ parents ~ enumBaseType;
 
     if(!cursor.isDefinition) return [firstLine ~ `;`];
 
@@ -699,4 +700,17 @@ private string maybeParents(
     return parents.empty
         ? ""
         : ": " ~ parents.join(", ");
+}
+
+private string maybeEnumBaseType(in from!"clang".Cursor cursor, in string dKeyword)
+    @safe
+{
+    import std.algorithm: map, minElement, maxElement;
+
+    if(dKeyword != "enum") return "";
+
+    auto enumValues = cursor.children.map!(a => a.enumConstantValue);
+    bool shouldPromote = enumValues.maxElement > int.max || enumValues.minElement < int.min;
+
+    return shouldPromote ? " : long" : "";
 }

--- a/tests/it/c/compile/enum_.d
+++ b/tests/it/c/compile/enum_.d
@@ -351,17 +351,20 @@ import it;
 @safe unittest {
     shouldCompile(
         C(
-            q{
-                enum Promoted { A = 1, B = 68719476704 };
+            `
+                #include <limits.h>
+                enum Promoted { A = 1, B = LONG_MAX };
                 enum NotPromoted { C = 1, D = 3 };
-            }
+            `
          ),
 
         D(
             q{
+                import core.stdc.config : c_long;
                 auto a = Promoted.A;
                 auto b = Promoted.B;
-                static assert(Promoted.sizeof == long.sizeof);
+                static assert(c_long.max == Promoted.B);
+                static assert(Promoted.sizeof == c_long.sizeof);
                 static assert(NotPromoted.sizeof == int.sizeof);
             }
          ),

--- a/tests/it/c/compile/enum_.d
+++ b/tests/it/c/compile/enum_.d
@@ -346,3 +346,24 @@ import it;
          ),
     );
 }
+
+@("enumBaseType changed to long")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                enum Promoted { A = 1, B = 68719476704 };
+                enum NotPromoted { C = 1, D = 3 };
+            }
+         ),
+
+        D(
+            q{
+                auto a = Promoted.A;
+                auto b = Promoted.B;
+                static assert(Promoted.sizeof == long.sizeof);
+                static assert(NotPromoted.sizeof == int.sizeof);
+            }
+         ),
+    );
+}


### PR DESCRIPTION
```d
enum Enum1 { A = 68719476704 }; // Compiles fine in both C and D
enum Enum2 { A = 68719476704, B = 1 }; // Still compiles fine in both C and D
enum Enum3 { B = 1, A = 68719476704 }; // Compiles in C, in D => Error: cannot implicitly convert expression 68719476704L of type long to int
```
In the last case the EnumBaseType is inferred by looking at just the first enum value, which is of type int.

In C, sizeof(enum Enum3) is 8 and sizef(enum Enum1/Enum2) is 4. So changing the EnumBaseType to long if a value from the enum overflows int seems ok to me. I'm not sure if this could impact something else I'm not aware of.

EDIT: The unit test I've added passed locally, but now I see that the AppVeyor build test fails.