### PR TITLE
Wrong bitfields paddings are no longer generated if the current member should be skipped

### DIFF
--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -210,9 +210,9 @@ string[] translateAggregate(
             continue;
         }
 
-        lines ~= bitFieldInfo.handle(child);
-
         if(skipMember(child)) continue;
+
+        lines ~= bitFieldInfo.handle(child);
 
         const childTranslation = () {
 

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -95,7 +95,7 @@ version(Posix) // because Windows doesn't have signinfo
 
 
 @Tags("issue", "bitfield")
-@("7")
+@("7.0")
 @safe unittest {
     shouldCompile(
         C(
@@ -123,6 +123,31 @@ version(Posix) // because Windows doesn't have signinfo
         ),
     );
 }
+
+@Tags("issue", "bitfield")
+@("7.1")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct other {
+                    int a: 2;
+                    int b: 3;
+                    // field type of pointer to undeclared struct should not
+                    // affect the generated bitfields' syntax
+                    struct A *ptr;
+                };
+            }
+        ),
+        D(
+            q{
+                other o;
+            }
+        ),
+    );
+}
+
+
 
 @Tags("issue")
 @("10")


### PR DESCRIPTION
The following C struct declaration
```c
struct Bad {
    int a : 1;
    int b : 1;
    struct C *ptr; // C is undeclared
}

```

would be translated in D to

```d
struct Bad
{
    import std.bitmanip: bitfields;

    align(4);
    mixin(bitfields!(
        int, "a", 1,
        int, "b", 1,
        uint, "_padding_0", 6
    ));
        uint, "_padding_1", 8
    ));
    C* ptr;
}
```

The issue is that the bitfields final padding would be added twice:
- for the StructDecl type (we handle bitfields before the skipMember check is done)
- for the actual FieldDecl type

This issue doesn't occur when C is a pre-declared struct, as we will only have a FieldDecl for that line.