### PR TITLE
Nested aggregates in C are now accessible outside of their parent when translated into D

### DIFF
--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -71,7 +71,7 @@ struct Context {
     private string[string] _aggregateSpelling;
 
     /**
-      Mapping between a child aggregate's name and its' parent aggregate's
+      Mapping between a child aggregate's name and its parent aggregate's
       name.
      */
     private string[string] _aggregateParents;

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -170,6 +170,8 @@ string[] translateAggregate(
     @safe
 {
     import dpp.translation.translation: translate;
+    import dpp.translation.type: hasAnonymousSpelling;
+    import dpp.runtime.context: Language;
     import clang: Cursor, Type, AccessSpecifier;
     import std.algorithm: map;
     import std.array: array;
@@ -214,6 +216,11 @@ string[] translateAggregate(
         if(skipMember(child)) continue;
 
         lines ~= bitFieldInfo.handle(child);
+
+        if (context.language == Language.C
+                && (child.type.kind == Type.Kind.Record || child.type.kind == Type.Kind.Enum)
+                && !child.type.hasAnonymousSpelling)
+            context.rememberAggregateParent(child, cursor);
 
         const childTranslation = () {
 
@@ -492,7 +499,7 @@ void maybeRememberStructs(R)(R types, ref from!"dpp.runtime.context".Context con
             ? removeConst.replace("volatile ", "")
             : removeConst;
 
-        context.rememberFieldStruct(translateElaborated(removeVolatile));
+        context.rememberFieldStruct(translateElaborated(removeVolatile, context));
     }
 
     foreach(structType; structTypes)

--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -102,7 +102,7 @@ private bool isStringRepr(T)(in string str) @safe pure {
 
 private string translateToD(
     in from!"clang".Cursor cursor,
-    in from!"dpp.runtime.context".Context context,
+    ref from!"dpp.runtime.context".Context context,
     in from!"clang".Token[] tokens,
     )
     @safe
@@ -117,7 +117,7 @@ private string translateToD(
         .fixArrow
         .fixNull
         .toString
-        .translateElaborated
+        .translateElaborated(context)
         ;
 }
 

--- a/source/dpp/translation/typedef_.d
+++ b/source/dpp/translation/typedef_.d
@@ -71,7 +71,7 @@ private string[] translateRegular(in from!"clang".Cursor cursor,
                                   in from!"clang".Cursor[] children)
     @safe
 {
-    import dpp.translation.type: translate;
+    import dpp.translation.type: translate, removeDppDecorators;
     import dpp.translation.aggregate: isAggregateC;
     import dpp.translation.dlang: maybeRename;
     import std.typecons: No;
@@ -88,7 +88,8 @@ private string[] translateRegular(in from!"clang".Cursor cursor,
 
             return isAnonymousAggregate
                 ? context.spellingOrNickname(children[0])
-                : translate(cursor.underlyingType, context, No.translatingFunction);
+                : translate(cursor.underlyingType, context, No.translatingFunction)
+                    .removeDppDecorators;
 
         // possible issues on 32-bit
         case "int32_t":  return "int";

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -853,3 +853,42 @@ import it;
         ),
     );
 }
+
+@("Accessing nested aggregates")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                struct A {
+                    struct B {
+                        int a;
+                        struct C {
+                            int b;
+                            enum E {Mon, Tue};
+                        } c_obj1;
+                    } b_obj;
+
+                    union U {
+                        int v1;
+                        char v2;
+                    };
+
+                    struct C c_obj2;
+                };
+
+                void f(struct C *);
+                void g(struct B *);
+                void h(union U *);
+                void i(enum E);
+            }
+        ),
+        D(
+            q{
+                A a_obj;
+                a_obj.b_obj.c_obj1.b = 3;
+
+                A.B.C.E day = A.B.C.E.Mon;
+            }
+        ),
+    );
+}


### PR DESCRIPTION
Solution for an issue that occured in the case below:

```c
struct A {
    struct B {
        int a;
        int c;
    } b_obj;
    int other;
};

void f(struct B*); // works in C, in D it should be A.B
// Also applicable to field types
```

The f function, when translated, would have the parameter of type B* instead of A.B*.
The solution only applies to C (as C++ has namespaces), to struct, union and enum, at any level of nested aggregates.

The solution is based on an associative array which keeps track of aggregate's spelling and their parent's spelling (as well as the line number in which they appear), so that, in the end, we can go to those lines and modify the parameter type (or field type, depending on the case).

EDIT: Another possible solution could be recording the child-parent aggregates like before, and just specifying some aliases (in the case above, alias B = A.B), instead of remembering every line where that aggregate type appeared and modify B to A.B. I didn't think that long for this solution (so I don't know if there are cases where it won't work), but if it is considered better, I can modify the current solution.