### PR TITLE
C preprocessor warnings are no longer written to the .d file

### DIFF
--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -227,7 +227,7 @@ private bool isModuleLine(in const(char)[] line) @safe pure {
 private void runCPreProcessor(in string cppPath, in string tmpFileName, in string outputFileName) @safe {
 
     import std.exception: enforce;
-    import std.process: execute;
+    import std.process: execute, Config;
     import std.conv: text;
     import std.string: join, splitLines;
     import std.stdio: File;
@@ -243,7 +243,7 @@ private void runCPreProcessor(in string cppPath, in string tmpFileName, in strin
     const cppArgs = [cpp, tmpFileName];
     const ret = () {
         try
-            return execute(cppArgs);
+            return execute(cppArgs, null, Config.stderrPassThrough);
         catch (Exception e)
         {
             import std.typecons : Tuple;

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -892,3 +892,24 @@ import it;
         ),
     );
 }
+
+@("C preprocessor warnings should not be written to file")
+@safe unittest {
+
+    with(immutable IncludeSandbox()) {
+
+        writeFile("hdr.h",
+                  `
+                  #define A B(__VA_ARGS__)
+                  `);
+
+        writeFile("app.dpp",
+                  `
+                      #include "hdr.h"
+                  `);
+
+        runPreprocessOnly("app.dpp");
+        shouldCompile("app.d");
+    }
+
+}


### PR DESCRIPTION
A quick note: I've not been able to run ci.sh neither before my change nor after. Output:
Error: Error writing '
'
dmd failed with exit code 1.

I've tested locally with roughly the same code I added in the unittest.