### PR TITLE
Extern void variables are now translated into extern void* variables

### DIFF
--- a/source/dpp/translation/variable.d
+++ b/source/dpp/translation/variable.d
@@ -17,7 +17,7 @@ string[] translateVariable(in from!"clang".Cursor cursor,
     import std.conv: text;
     import std.typecons: No;
     import std.algorithm: canFind, find, map;
-    import std.array: empty, popFront, join;
+    import std.array: empty, popFront, join, replace;
 
     string[] ret;
 
@@ -53,11 +53,14 @@ string[] translateVariable(in from!"clang".Cursor cursor,
     if(constexpr)
         ret ~= translateConstexpr(spelling, cursor, context);
     else {
-
+        const typeSpelling = translateType(cursor.type, context, No.translatingFunction);
+        // In C it is possible to have an extern void variable
+        const typeNotVoid = (typeSpelling == "void" || typeSpelling == "const(void)")
+                            ? typeSpelling.replace("void", "void*"): typeSpelling;
         ret ~=
             maybePragma(cursor, context) ~
             text("extern __gshared ", static_,
-                 translateType(cursor.type, context, No.translatingFunction), " ", spelling, ";");
+                 typeNotVoid, " ", spelling, ";");
     }
 
     return ret;

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -892,3 +892,26 @@ import it;
         ),
     );
 }
+
+@("Extern void variable")
+@safe unittest {
+    shouldCompile(
+        C(
+            q{
+                extern void v;
+                extern const void cv;
+            }
+        ),
+        D(
+            q{
+                static assert(is(typeof(v) == void*,
+                              "Expected void*, not " ~
+                              typeof(v).stringof);
+
+                static assert(is(typeof(cv) == const(void*),
+                              "Expected const(void*), not " ~
+                              typeof(cv).stringof);
+            }
+        ),
+    );
+}

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -904,11 +904,11 @@ import it;
         ),
         D(
             q{
-                static assert(is(typeof(v) == void*,
+                static assert(is(typeof(v) == void*),
                               "Expected void*, not " ~
                               typeof(v).stringof);
 
-                static assert(is(typeof(cv) == const(void*),
+                static assert(is(typeof(cv) == const(void*)),
                               "Expected const(void*), not " ~
                               typeof(cv).stringof);
             }


### PR DESCRIPTION
Such a case happened as a result of translating linux/include/asm-generic/sections.h, where we have
```c
extern __visible const void __nosave_begin, __nosave_end;
```
Discussed with Edi and Razvan who suggested that this void type could be changed to a pointer type.