### PR TITLE
Perform type casting when the type has macro attributes

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -371,6 +371,13 @@ private auto fixCasts(R)(
             )
             return true;
 
+        if ( // macro attribute (e.g. __force) + type
+            tokens.length >= 2
+            && tokens[0].kind == Token.Kind.Identifier
+            && isType(tokens[1..$])
+            )
+            return true;
+
         return false;
     }
 

--- a/tests/it/c/compile/projects.d
+++ b/tests/it/c/compile/projects.d
@@ -854,6 +854,25 @@ import it;
     );
 }
 
+@("Casting when type has attribute")
+@safe unittest {
+    shouldCompile(
+         C(
+            `
+                typedef unsigned int gfp_t;
+
+                #define DUMMY ((__force gfp_t) 7)
+                #define __force
+            `
+        ),
+        D(
+            q{
+                auto a = DUMMY;
+            }
+        ),
+    );
+}
+
 @("Accessing nested aggregates")
 @safe unittest {
     shouldCompile(


### PR DESCRIPTION
For a concrete example, see the [GFP_ATOMIC](https://elixir.bootlin.com/linux/latest/source/include/linux/gfp.h#L118) macro definition from the linux kernel, where the attribute '__force' is used with a type cast.

LE: I previously tried to add the condition that tokens[0] should be a macro, but I found out that the macro could have been declared later on. The unit test showcases this: '__force' is defined after being used.