### PR TITLE
Perform type casting with typeof

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -371,6 +371,12 @@ private auto fixCasts(R)(
             )
             return true;
 
+        if( // typeof
+            tokens.length >= 2
+            && tokens[0] == Token(Token.Kind.Keyword, "typeof")
+            )
+            return true;
+
         return false;
     }
 

--- a/tests/it/c/compile/extensions.d
+++ b/tests/it/c/compile/extensions.d
@@ -26,3 +26,20 @@ import it;
         ),
     );
 }
+
+@("Type cast with typeof")
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                #define DUMMY(x) (sizeof((typeof(x) *)1))
+            `
+        ),
+
+        D(
+            q{
+                auto a = DUMMY(7);
+            }
+        ),
+    );
+}


### PR DESCRIPTION
For a concrete example, see the [__typecheck](https://elixir.bootlin.com/linux/latest/source/include/linux/kernel.h#L834) macro definition from the linux kernel.