### PR TITLE
Add option to specify which macros to ignore

### DIFF
--- a/source/dpp/runtime/options.d
+++ b/source/dpp/runtime/options.d
@@ -30,6 +30,7 @@ struct Options {
     bool hardFail;
     bool cppStdLib;
     bool ignoreMacros;
+    string[] ignoredMacros;
     bool detailedUntranslatable;
     string[] ignoredNamespaces;
     string[] ignoredCursors;
@@ -125,6 +126,7 @@ struct Options {
                 "hard-fail", "Translate nothing if any part fails", &hardFail,
                 "c++-std-lib", "Link to the C++ standard library", &cppStdLib,
                 "ignore-macros", "Ignore preprocessor macros", &ignoreMacros,
+                "ignore-specified-macros", "Ignore the specified preprocessor macros", &ignoredMacros,
                 "ignore-ns", "Ignore a C++ namespace", &ignoredNamespaces,
                 "ignore-cursor", "Ignore a C++ cursor", &ignoredCursors,
                 "ignore-path", "Ignore a file path, note it globs so you will want to use *", &ignoredPaths,
@@ -146,6 +148,7 @@ struct Options {
             );
 
         clangOptions = map!(e => e.split(" "))(clangOptions).join();
+        ignoredMacros = map!(e => e.split(","))(ignoredMacros).join();
 
         if(helpInfo.helpWanted) {
             () @trusted {

--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -15,8 +15,9 @@ string[] translateMacro(in from!"clang".Cursor cursor,
 
     // we want non-built-in macro definitions to be defined and then preprocessed
     // again
-
     if(isBuiltinMacro(cursor)) return [];
+
+    if (context.options.ignoredMacros.canFind(cursor.spelling)) return [];
 
     const tokens = cursor.tokens;
 


### PR DESCRIPTION
E.g. in include/linux/kernel.h, there are macro definitions for max and min, which conflict with dlang's own max and min functions present in the .dpp file. In this case, I use d++ with --ignore-specified-macros "min,max"