### PR TITLE
Preserve the documentation

### DIFF
--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -254,7 +254,7 @@ private void runCPreProcessor(in string cppPath, in string tmpFileName, in strin
 
     const cpp = cppPath == "" ? cppDefault : cppPath;
 
-    const cppArgs = [cpp, "-w", tmpFileName];
+    const cppArgs = [cpp, "-w", "--comments", tmpFileName];
     const ret = () {
         try {
             string[string] env;

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -414,7 +414,7 @@ string[] translateField(in from!"clang".Cursor field,
 
     return field.isBitField
         ? translateBitField(field, context, type)
-        : [text(type, " ", maybeRename(field, context), ";")];
+        : [get_comment(field, false), text(type, " ", maybeRename(field, context), ";")];
 }
 
 string[] translateBitField(in from!"clang".Cursor cursor,
@@ -430,7 +430,7 @@ string[] translateBitField(in from!"clang".Cursor cursor,
     // no name. See issue #35.
     if(spelling == "") spelling = context.newAnonymousMemberName;
 
-    return [text("    ", type, `, "`, spelling, `", `, cursor.bitWidth, `,`)];
+    return [get_comment(cursor, false), text("    ", type, `, "`, spelling, `", `, cursor.bitWidth, `,`)];
 }
 
 private from!"clang".Type pointeeTypeFor(in from!"clang".Type type)

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -4,6 +4,7 @@
 module dpp.translation.aggregate;
 
 import dpp.from;
+import dpp.translation.docs;
 import std.range: isInputRange;
 
 
@@ -246,6 +247,9 @@ string[] translateAggregate(
     lines ~= maybeDisableDefaultCtor(cursor, dKeyword);
 
     lines ~= `}`;
+
+    // attach struct docs
+    lines = get_comment(cursor, false) ~ lines;
 
     return lines;
 }

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -249,7 +249,7 @@ string[] translateAggregate(
     lines ~= `}`;
 
     // attach struct docs
-    lines = get_comment(cursor, false) ~ lines;
+    lines = getComment(cursor) ~ lines;
 
     return lines;
 }
@@ -414,7 +414,7 @@ string[] translateField(in from!"clang".Cursor field,
 
     return field.isBitField
         ? translateBitField(field, context, type)
-        : [get_comment(field, false), text(type, " ", maybeRename(field, context), ";")];
+        : [getComment(field), text(type, " ", maybeRename(field, context), ";")];
 }
 
 string[] translateBitField(in from!"clang".Cursor cursor,
@@ -430,7 +430,7 @@ string[] translateBitField(in from!"clang".Cursor cursor,
     // no name. See issue #35.
     if(spelling == "") spelling = context.newAnonymousMemberName;
 
-    return [get_comment(cursor, false), text("    ", type, `, "`, spelling, `", `, cursor.bitWidth, `,`)];
+    return [getComment(cursor), text("    ", type, `, "`, spelling, `", `, cursor.bitWidth, `,`)];
 }
 
 private from!"clang".Type pointeeTypeFor(in from!"clang".Type type)

--- a/source/dpp/translation/docs.d
+++ b/source/dpp/translation/docs.d
@@ -1,0 +1,14 @@
+module dpp.translation.docs;
+
+import dpp.from;
+
+/** Get the attached comments at the location of the cursor */
+string get_comment(in from!"clang".Cursor cursor) @safe {
+    import std.typecons: Nullable;
+    string docStr = "";
+    Nullable!string nullableComment = cursor.raw_comment();
+    if(!nullableComment.isNull) {
+        docStr = nullableComment.get() ~ "\n    ";
+    }
+    return docStr;
+}

--- a/source/dpp/translation/docs.d
+++ b/source/dpp/translation/docs.d
@@ -3,15 +3,12 @@ module dpp.translation.docs;
 import dpp.from;
 
 /** Get the attached comments at the location of the cursor */
-string getComment(in from!"clang".Cursor cursor, bool breakln = false) @safe {
+string getComment(in from!"clang".Cursor cursor) @safe {
     import std.typecons: Nullable;
     string docStr = "";
     Nullable!string nullableComment = cursor.raw_comment();
     if(!nullableComment.isNull) {
         docStr = nullableComment.get();
-        if (breakln) {
-            docStr ~= "\n    ";
-        }
     }
     return docStr;
 }

--- a/source/dpp/translation/docs.d
+++ b/source/dpp/translation/docs.d
@@ -3,7 +3,7 @@ module dpp.translation.docs;
 import dpp.from;
 
 /** Get the attached comments at the location of the cursor */
-string get_comment(in from!"clang".Cursor cursor, bool breakln = true) @safe {
+string getComment(in from!"clang".Cursor cursor, bool breakln = false) @safe {
     import std.typecons: Nullable;
     string docStr = "";
     Nullable!string nullableComment = cursor.raw_comment();

--- a/source/dpp/translation/docs.d
+++ b/source/dpp/translation/docs.d
@@ -3,12 +3,15 @@ module dpp.translation.docs;
 import dpp.from;
 
 /** Get the attached comments at the location of the cursor */
-string get_comment(in from!"clang".Cursor cursor) @safe {
+string get_comment(in from!"clang".Cursor cursor, bool breakln = true) @safe {
     import std.typecons: Nullable;
     string docStr = "";
     Nullable!string nullableComment = cursor.raw_comment();
     if(!nullableComment.isNull) {
-        docStr = nullableComment.get() ~ "\n    ";
+        docStr = nullableComment.get();
+        if (breakln) {
+            docStr ~= "\n    ";
+        }
     }
     return docStr;
 }

--- a/source/dpp/translation/enum_.d
+++ b/source/dpp/translation/enum_.d
@@ -4,6 +4,7 @@
 module dpp.translation.enum_;
 
 import dpp.from;
+import dpp.translation.docs;
 
 string[] translateEnumConstant(in from!"clang".Cursor cursor,
                                ref from!"dpp.runtime.context".Context context)
@@ -16,5 +17,6 @@ string[] translateEnumConstant(in from!"clang".Cursor cursor,
     assert(cursor.kind == Cursor.Kind.EnumConstantDecl);
     context.log("    Enum Constant Value: ", cursor.enumConstantValue);
     context.log("    tokens: ", cursor.tokens);
-    return [maybeRename(cursor, context) ~ ` = ` ~ text(cursor.enumConstantValue) ~ `, `];
+
+    return [get_comment(cursor, false), maybeRename(cursor, context) ~ ` = ` ~ text(cursor.enumConstantValue) ~ `, `];
 }

--- a/source/dpp/translation/enum_.d
+++ b/source/dpp/translation/enum_.d
@@ -18,5 +18,5 @@ string[] translateEnumConstant(in from!"clang".Cursor cursor,
     context.log("    Enum Constant Value: ", cursor.enumConstantValue);
     context.log("    tokens: ", cursor.tokens);
 
-    return [get_comment(cursor, false), maybeRename(cursor, context) ~ ` = ` ~ text(cursor.enumConstantValue) ~ `, `];
+    return [getComment(cursor), maybeRename(cursor, context) ~ ` = ` ~ text(cursor.enumConstantValue) ~ `, `];
 }

--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -163,7 +163,7 @@ private string functionDecl(
         // Add the comment before the function definition
         Nullable!string nullableComment = cursor.raw_comment();
         if(!nullableComment.isNull) {
-            ret ~= nullableComment.get();
+            ret ~= nullableComment.get() ~ "\n    ";
         }
 
         if(cursor.semanticParent.dKeywordFromStrass == "struct")

--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -44,7 +44,7 @@ string[] translateFunction(in from!"clang".Cursor cursor,
     const spelling = functionSpelling(cursor, context);
 
     lines ~= [
-        maybePragma(cursor, context) ~ functionDecl(cursor, context, spelling)
+        getComment(cursor), maybePragma(cursor, context) ~ functionDecl(cursor, context, spelling)
     ];
 
     context.log("");
@@ -177,7 +177,7 @@ private string functionDecl(
         return ret;
     }
 
-    return text(getComment(cursor, true), prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
+    return text(prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
 }
 
 private string returnType(in from!"clang".Cursor cursor,

--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -177,7 +177,7 @@ private string functionDecl(
         return ret;
     }
 
-    return text(get_comment(cursor), prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
+    return text(getComment(cursor, true), prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
 }
 
 private string returnType(in from!"clang".Cursor cursor,

--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -4,6 +4,7 @@
 module dpp.translation.function_;
 
 import dpp.from;
+import dpp.translation.docs;
 
 
 enum OPERATOR_PREFIX = "operator";
@@ -156,27 +157,19 @@ private string functionDecl(
 
     string prefix() {
         import dpp.translation.aggregate: dKeywordFromStrass;
-        import std.typecons;
-
-        string ret;
-
-        // Add the comment before the function definition
-        Nullable!string nullableComment = cursor.raw_comment();
-        if(!nullableComment.isNull) {
-            ret ~= nullableComment.get() ~ "\n    ";
-        }
 
         if(cursor.semanticParent.dKeywordFromStrass == "struct")
-            return ret ~ "";
+            return "";
 
         if(cursor.isPureVirtual)
-            return ret ~ "abstract ";
+            return "abstract ";
 
         if(!cursor.isVirtual)
-            return ret ~ "final ";
+            return "final ";
 
         // If we get here it's a virtual member function.
         // We might need to add D `final` and/or `override`.
+        string ret;
 
         if(cursor.isOverride) ret ~= "override ";
         if(cursor.isFinal) ret ~= "final ";
@@ -184,7 +177,7 @@ private string functionDecl(
         return ret;
     }
 
-    return text(prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
+    return text(get_comment(cursor), prefix, returnType, " ", spelling, ctParams, "(", params, ") @nogc nothrow", const_, ";");
 }
 
 private string returnType(in from!"clang".Cursor cursor,

--- a/source/dpp/translation/function_.d
+++ b/source/dpp/translation/function_.d
@@ -129,6 +129,9 @@ private string functionDecl(
     import std.algorithm: endsWith, canFind;
     import std.array: join;
 
+    () @trusted {
+        context.log("Comment (raw):  ", cursor.raw_comment());
+    }();
     context.log("Function return type (raw):        ", cursor.type.returnType);
     context.log("Function children: ", cursor.children);
     context.log("Function paramTypes: ", cursor.type.paramTypes);
@@ -153,19 +156,27 @@ private string functionDecl(
 
     string prefix() {
         import dpp.translation.aggregate: dKeywordFromStrass;
+        import std.typecons;
+
+        string ret;
+
+        // Add the comment before the function definition
+        Nullable!string nullableComment = cursor.raw_comment();
+        if(!nullableComment.isNull) {
+            ret ~= nullableComment.get();
+        }
 
         if(cursor.semanticParent.dKeywordFromStrass == "struct")
-            return "";
+            return ret ~ "";
 
         if(cursor.isPureVirtual)
-            return "abstract ";
+            return ret ~ "abstract ";
 
         if(!cursor.isVirtual)
-            return "final ";
+            return ret ~ "final ";
 
         // If we get here it's a virtual member function.
         // We might need to add D `final` and/or `override`.
-        string ret;
 
         if(cursor.isOverride) ret ~= "override ";
         if(cursor.isFinal) ret ~= "final ";

--- a/source/dpp/translation/typedef_.d
+++ b/source/dpp/translation/typedef_.d
@@ -5,6 +5,7 @@ module dpp.translation.typedef_;
 
 
 import dpp.from;
+import dpp.translation.docs;
 
 
 string[] translateTypedef(in from!"clang".Cursor cursor,
@@ -108,7 +109,7 @@ private string[] translateRegular(in from!"clang".Cursor cursor,
     // makes no sense in D.
     return cursor.spelling == underlyingSpelling
         ? []
-        : [`alias ` ~ maybeRename(cursor, context) ~ ` = ` ~ underlyingSpelling  ~ `;`];
+        : [getComment(cursor), `alias ` ~ maybeRename(cursor, context) ~ ` = ` ~ underlyingSpelling  ~ `;`];
 }
 
 

--- a/source/dpp/translation/variable.d
+++ b/source/dpp/translation/variable.d
@@ -65,7 +65,7 @@ string[] translateVariable(in from!"clang".Cursor cursor,
     }
 
     // attach variable docs
-    ret = get_comment(cursor, false) ~ ret;
+    ret = getComment(cursor) ~ ret;
 
     return ret;
 }

--- a/source/dpp/translation/variable.d
+++ b/source/dpp/translation/variable.d
@@ -1,6 +1,7 @@
 module dpp.translation.variable;
 
 import dpp.from;
+import dpp.translation.docs;
 
 string[] translateVariable(in from!"clang".Cursor cursor,
                            ref from!"dpp.runtime.context".Context context)
@@ -62,6 +63,9 @@ string[] translateVariable(in from!"clang".Cursor cursor,
             maybePragma(cursor, context) ~
             text("extern __gshared ", static_, typeSpelling, " ", spelling, ";");
     }
+
+    // attach variable docs
+    ret = get_comment(cursor, false) ~ ret;
 
     return ret;
 }

--- a/tests/it/docs.d
+++ b/tests/it/docs.d
@@ -17,105 +17,107 @@ auto normalizeLines(string text) {
 }
 
 
-@("The Cpp documentation is preserved")
-@safe unittest {
-    with(immutable IncludeSandbox()) {
+version(Windows) {
+    @("The Cpp documentation is preserved")
+    @safe unittest {
+        with(immutable IncludeSandbox()) {
 
-        writeFile("hdr.hpp",
-                  `
-                      /** f1 doc */
-                      void f1() {}
+            writeFile("hdr.hpp",
+                      `
+                          /** f1 doc */
+                          void f1() {}
 
-                      // f2 non-doc
-                      void f2() {}
+                          // f2 non-doc
+                          void f2() {}
 
-                      /// f3 doc
-                      void f3() {}
+                          /// f3 doc
+                          void f3() {}
 
-                      /** variable1 doc */
-                      int variable1 = 1 + 2;
+                          /** variable1 doc */
+                          int variable1 = 1 + 2;
 
-                      /// variable2 doc
-                      int variable2 = 1 + 2;
+                          /// variable2 doc
+                          int variable2 = 1 + 2;
 
-                      // variable3 non-doc
-                      int variable3 = 1 + 2;
-
-
-                      /** Struct1 doc */
-                      struct Struct1 {
-
-                        /** prop1 doc */
-                        int prop1;
-
-                        /** method1 doc */
-                        void method1();
-                      };
+                          // variable3 non-doc
+                          int variable3 = 1 + 2;
 
 
-                      /** Enum1 doc */
-                      enum Enum1 {
-                        /** x doc */
-                        x,
-                        /// y doc
-                        y,
-                        // z non doc
-                        z,
-                      };
+                          /** Struct1 doc */
+                          struct Struct1 {
 
-                      /** Type1 doc */
-                      typedef int Type1;`);
-        writeFile("main.dpp",
-                  `
-                      #include "hdr.hpp"
-                  `);
-        runPreprocessOnly(
-            "--source-output-path",
-            inSandboxPath("foo/bar"),
-            "main.dpp",
-        );
+                            /** prop1 doc */
+                            int prop1;
 
-        auto originalText = readText(inSandboxPath("foo/bar/main.d"));
-        auto needle = `extern(C++)
-        {
-            /** Type1 doc */
-            alias Type1 = int;
-            /** Enum1 doc */
-            enum Enum1
+                            /** method1 doc */
+                            void method1();
+                          };
+
+
+                          /** Enum1 doc */
+                          enum Enum1 {
+                            /** x doc */
+                            x,
+                            /// y doc
+                            y,
+                            // z non doc
+                            z,
+                          };
+
+                          /** Type1 doc */
+                          typedef int Type1;`);
+            writeFile("main.dpp",
+                      `
+                          #include "hdr.hpp"
+                      `);
+            runPreprocessOnly(
+                "--source-output-path",
+                inSandboxPath("foo/bar"),
+                "main.dpp",
+            );
+
+            auto originalText = readText(inSandboxPath("foo/bar/main.d"));
+            auto needle = `extern(C++)
             {
-                /** x doc */
-                x = 0,
-                /// y doc
-                y = 1,
-                /// y doc
-                z = 2,
-            }
-            enum x = Enum1.x;
-            enum y = Enum1.y;
-            enum z = Enum1.z;
-            /** Struct1 doc */
-            struct Struct1
-            {
-                /** prop1 doc */
-                int prop1;
-                /** method1 doc */
-                pragma(mangle, "?method1@Struct1@@QEAAXXZ") void method1() @nogc nothrow;
-            }
+                /** Type1 doc */
+                alias Type1 = int;
+                /** Enum1 doc */
+                enum Enum1
+                {
+                    /** x doc */
+                    x = 0,
+                    /// y doc
+                    y = 1,
+                    /// y doc
+                    z = 2,
+                }
+                enum x = Enum1.x;
+                enum y = Enum1.y;
+                enum z = Enum1.z;
+                /** Struct1 doc */
+                struct Struct1
+                {
+                    /** prop1 doc */
+                    int prop1;
+                    /** method1 doc */
+                    pragma(mangle, "?method1@Struct1@@QEAAXXZ") void method1() @nogc nothrow;
+                }
 
-            pragma(mangle, "?variable3@@3HA") extern __gshared int variable3;
-            /// variable2 doc
-            pragma(mangle, "?variable2@@3HA") extern __gshared int variable2;
-            /** variable1 doc */
-            pragma(mangle, "?variable1@@3HA") extern __gshared int variable1;
-            /// f3 doc
-            pragma(mangle, "?f3@@YAXXZ") void f3() @nogc nothrow;
+                pragma(mangle, "?variable3@@3HA") extern __gshared int variable3;
+                /// variable2 doc
+                pragma(mangle, "?variable2@@3HA") extern __gshared int variable2;
+                /** variable1 doc */
+                pragma(mangle, "?variable1@@3HA") extern __gshared int variable1;
+                /// f3 doc
+                pragma(mangle, "?f3@@YAXXZ") void f3() @nogc nothrow;
 
-            pragma(mangle, "?f2@@YAXXZ") void f2() @nogc nothrow;
-            /** f1 doc */
-            pragma(mangle, "?f1@@YAXXZ") void f1() @nogc nothrow;
-        }`;
-    needle.normalizeLines().shouldBeIn(originalText[originalText.indexOf("extern(C++)")..$].normalizeLines());
+                pragma(mangle, "?f2@@YAXXZ") void f2() @nogc nothrow;
+                /** f1 doc */
+                pragma(mangle, "?f1@@YAXXZ") void f1() @nogc nothrow;
+            }`;
+        needle.normalizeLines().shouldBeIn(originalText[originalText.indexOf("extern(C++)")..$].normalizeLines());
 
+        }
     }
 }
 

--- a/tests/it/docs.d
+++ b/tests/it/docs.d
@@ -1,0 +1,216 @@
+module it.docs;
+
+import it;
+import dpp.translation;
+import unit_threaded: shouldEqual, Sandbox;
+
+import std.file: readText;
+import std.string: indexOf;
+
+import unit_threaded.assertions: shouldBeIn;
+
+auto normalizeLines(string text) {
+    import std.string: strip, lineSplitter;
+    import std.algorithm: map;
+    import std.array: join;
+    return text.lineSplitter().map!(line => line.strip()).join('\n');
+}
+
+
+@("The Cpp documentation is preserved")
+@safe unittest {
+    with(immutable IncludeSandbox()) {
+
+        writeFile("hdr.hpp",
+                  `
+                      /** f1 doc */
+                      void f1() {}
+
+                      // f2 non-doc
+                      void f2() {}
+
+                      /// f3 doc
+                      void f3() {}
+
+                      /** variable1 doc */
+                      int variable1 = 1 + 2;
+
+                      /// variable2 doc
+                      int variable2 = 1 + 2;
+
+                      // variable3 non-doc
+                      int variable3 = 1 + 2;
+
+
+                      /** Struct1 doc */
+                      struct Struct1 {
+
+                        /** prop1 doc */
+                        int prop1;
+
+                        /** method1 doc */
+                        void method1();
+                      };
+
+
+                      /** Enum1 doc */
+                      enum Enum1 {
+                        /** x doc */
+                        x,
+                        /// y doc
+                        y,
+                        // z non doc
+                        z,
+                      };
+
+                      /** Type1 doc */
+                      typedef int Type1;`);
+        writeFile("main.dpp",
+                  `
+                      #include "hdr.hpp"
+                  `);
+        runPreprocessOnly(
+            "--source-output-path",
+            inSandboxPath("foo/bar"),
+            "main.dpp",
+        );
+
+        auto originalText = readText(inSandboxPath("foo/bar/main.d"));
+        auto needle = `extern(C++)
+        {
+            /** Type1 doc */
+            alias Type1 = int;
+            /** Enum1 doc */
+            enum Enum1
+            {
+                /** x doc */
+                x = 0,
+                /// y doc
+                y = 1,
+                /// y doc
+                z = 2,
+            }
+            enum x = Enum1.x;
+            enum y = Enum1.y;
+            enum z = Enum1.z;
+            /** Struct1 doc */
+            struct Struct1
+            {
+                /** prop1 doc */
+                int prop1;
+                /** method1 doc */
+                pragma(mangle, "?method1@Struct1@@QEAAXXZ") void method1() @nogc nothrow;
+            }
+
+            pragma(mangle, "?variable3@@3HA") extern __gshared int variable3;
+            /// variable2 doc
+            pragma(mangle, "?variable2@@3HA") extern __gshared int variable2;
+            /** variable1 doc */
+            pragma(mangle, "?variable1@@3HA") extern __gshared int variable1;
+            /// f3 doc
+            pragma(mangle, "?f3@@YAXXZ") void f3() @nogc nothrow;
+
+            pragma(mangle, "?f2@@YAXXZ") void f2() @nogc nothrow;
+            /** f1 doc */
+            pragma(mangle, "?f1@@YAXXZ") void f1() @nogc nothrow;
+        }`;
+    needle.normalizeLines().shouldBeIn(originalText[originalText.indexOf("extern(C++)")..$].normalizeLines());
+
+    }
+}
+
+@("The C documentation is preserved")
+@safe unittest {
+    with(immutable IncludeSandbox()) {
+        writeFile("hdr.h",
+                  `
+                      /** f1 doc */
+                      void f1() {}
+
+                      // f2 non-doc
+                      void f2() {}
+
+                      /// f3 doc
+                      void f3() {}
+
+                      /** variable1 doc */
+                      int variable1 = 1 + 2;
+
+                      /// variable2 doc
+                      int variable2 = 1 + 2;
+
+                      // variable3 non-doc
+                      int variable3 = 1 + 2;
+
+
+                      /** Struct1 doc */
+                      struct Struct1 {
+
+                        /** prop1 doc */
+                        int prop1;
+                      };
+
+
+                      /** Enum1 doc */
+                      enum Enum1 {
+                        /** x doc */
+                        x,
+                        /// y doc
+                        y,
+                        // z non doc
+                        z,
+                      };
+
+                      /** Type1 doc */
+                      typedef int Type1;
+                  `);
+        writeFile("main.dpp",
+                  `
+                      #include "hdr.h"
+                  `);
+        runPreprocessOnly(
+            "--source-output-path",
+            inSandboxPath("foo/bar"),
+            "main.dpp",
+        );
+
+        auto originalText = readText(inSandboxPath("foo/bar/main.d"));
+        auto needle = `extern(C)
+        {
+            /** Type1 doc */
+            alias Type1 = int;
+            /** Enum1 doc */
+            enum Enum1
+            {
+                /** x doc */
+                x = 0,
+                /// y doc
+                y = 1,
+                /// y doc
+                z = 2,
+            }
+            enum x = Enum1.x;
+            enum y = Enum1.y;
+            enum z = Enum1.z;
+            /** Struct1 doc */
+            struct Struct1
+            {
+                /** prop1 doc */
+                int prop1;
+            }
+
+            extern __gshared int variable3;
+            /// variable2 doc
+            extern __gshared int variable2;
+            /** variable1 doc */
+            extern __gshared int variable1;
+            /// f3 doc
+            void f3() @nogc nothrow;
+
+            void f2() @nogc nothrow;
+            /** f1 doc */
+            void f1() @nogc nothrow;
+        }`;
+        needle.normalizeLines().shouldBeIn(originalText[originalText.indexOf("extern(C)")..$].normalizeLines());
+    }
+}

--- a/tests/it/main.d
+++ b/tests/it/main.d
@@ -4,6 +4,7 @@ import unit_threaded.runner;
 mixin runTestsMain!(
     "it.issues",
     "it.expansion",
+    "it.docs",
 
     // C tests
     "it.c.compile.preprocessor",

--- a/tests/test_main.d
+++ b/tests/test_main.d
@@ -1,3 +1,5 @@
+module tests.test_main;
+
 import unit_threaded.runner.runner;
 
 version(dpp2) {
@@ -46,6 +48,7 @@ version(dpp2) {
 
         "it.issues",
         "it.expansion",
+        "it.docs",
 
         // C tests
         "it.c.compile.preprocessor",


### PR DESCRIPTION
Dpp now preserves the documentation which means the editors will show data tips when the bound functions are used. :tada:


# Fixed issues
Fixes #140 


# Description

Preserve the documentation on:
- [x] functions
- [x] variables
- [x] struct/class itself
- [x] struct/class properties
- [x] struct/class methods
- [x] enum itself
- [x] enum properties
- [x] aliases

# Verification
All tests including the new ones pass:
![image](https://user-images.githubusercontent.com/16418197/120123232-46504e80-c173-11eb-979b-dc91d4d28147.png)


# Examples


Sample header file:

`test.dpp`
```cpp
#include "./test.hpp"
```
`test.hpp`
```cpp
/** f1 doc */
void f1() {}

// f2 non-doc
void f2() {}

/// f3 doc
void f3() {}

/** variable1 doc */
int variable1 = 1 + 2;

/// variable2 doc
int variable2 = 1 + 2;

// variable3 non-doc
int variable3 = 1 + 2;


/** Struct1 doc */
struct Struct1 {

  /** prop1 doc */
  int prop1;

  /** method1 doc */
  void method1();
};


/** Enum1 doc */
enum Enum1 {
  /** x doc */
  x,
  /// y doc
  y,
  // z non doc
  z,
};

/** Type1 doc */
typedef int Type1;
```

The output:
`test.d`
```d
extern(C++)
{
    /** Type1 doc */
    alias Type1 = int;
    /** Enum1 doc */
    enum Enum1
    {
        /** x doc */
        x = 0,
        /// y doc
        y = 1,
        /// y doc
        z = 2,
    }
    enum x = Enum1.x;
    enum y = Enum1.y;
    enum z = Enum1.z;
    /** Struct1 doc */
    struct Struct1
    {
        /** prop1 doc */
        int prop1;
        /** method1 doc */
        pragma(mangle, "?method1@Struct1@@QEAAXXZ") void method1() @nogc nothrow;
    }

    pragma(mangle, "?variable3@@3HA") extern __gshared int variable3;
    /// variable2 doc
    pragma(mangle, "?variable2@@3HA") extern __gshared int variable2;
    /** variable1 doc */
    pragma(mangle, "?variable1@@3HA") extern __gshared int variable1;
    /// f3 doc
    pragma(mangle, "?f3@@YAXXZ") void f3() @nogc nothrow;

    pragma(mangle, "?f2@@YAXXZ") void f2() @nogc nothrow;
    /** f1 doc */
    pragma(mangle, "?f1@@YAXXZ") void f1() @nogc nothrow;
}
```

# Future benefits

This also paves the way for optionally using the annotations in the docs to make better bindings.
For example, if a C function says that one of the parameters is `@param[in]`, then we can also make that parameter `in` inside the D header. There are a bunch of these special Doxygen attributes that we can potentially use:
https://www.doxygen.nl/manual/commands.html

