### PR TITLE
Add vaArgs only if macros are not ignored

### DIFF
--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -287,8 +287,10 @@ string preamble(bool ignoreMacros) @safe pure {
     import std.algorithm: map, filter;
     import std.string: splitLines;
 
-    string vaArgs = ignoreMacros ? "" : "    #define __gnuc_va_list va_list\n\n" ~
-        "    #define __is_empty(_Type) dpp.isEmpty!(_Type)\n";
+    const vaArgs = ignoreMacros
+        ? ""
+        : "    #define __gnuc_va_list va_list\n\n" ~
+          "    #define __is_empty(_Type) dpp.isEmpty!(_Type)\n";
 
     return q{
 

--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -129,7 +129,7 @@ private void preprocess(in from!"dpp.runtime.options".Options options,
         writeUndefLines(inputFileName, outputFile);
 
         outputFile.writeln(translationText.moduleDeclaration);
-        outputFile.writeln(preamble);
+        outputFile.writeln(preamble(options.ignoreMacros));
         outputFile.writeln(translationText.dlangDeclarations);
 
         // write original D code
@@ -282,10 +282,13 @@ private void runCPreProcessor(in string cppPath, in string tmpFileName, in strin
 }
 
 
-string preamble() @safe pure {
+string preamble(bool ignoreMacros) @safe pure {
     import std.array: replace, join;
     import std.algorithm: map, filter;
     import std.string: splitLines;
+
+    string vaArgs = ignoreMacros ? "" : "    #define __gnuc_va_list va_list\n\n" ~
+        "    #define __is_empty(_Type) dpp.isEmpty!(_Type)\n";
 
     return q{
 
@@ -299,8 +302,7 @@ string preamble() @safe pure {
 
         struct __locale_data { int dummy; }  // FIXME
     } ~
-          "    #define __gnuc_va_list va_list\n\n" ~
-          "    #define __is_empty(_Type) dpp.isEmpty!(_Type)\n" ~
+          vaArgs ~
 
           q{
         alias _Bool = bool;

--- a/tests/it/c/compile/runtime_args.d
+++ b/tests/it/c/compile/runtime_args.d
@@ -56,6 +56,31 @@ import it;
     }
 }
 
+@("--ignore-macros")
+@safe unittest {
+    with(immutable IncludeSandbox()) {
+        writeFile("includes/hdr.h",
+                  q{
+                      int add(int i, int j);
+                  });
+        writeFile("main.dpp",
+                  `
+                      #include "hdr.h"
+                      void main() {
+                          int ret = add(10, 20);
+                      }
+                  `);
+        runPreprocessOnly(
+            "--include-path",
+            "includes",
+            "--ignore-macros",
+            "main.dpp",
+        );
+
+        shouldCompile("main.d");
+    }
+}
+
 
 @("src output path")
 @safe unittest {

--- a/tests/it/package.d
+++ b/tests/it/package.d
@@ -182,7 +182,7 @@ private auto dropPreamble(R)(R lines) {
     import std.string: splitLines;
 
     const length = lines.save.walkLength;
-    const preambleLength = preamble.splitLines.length + 1;
+    const preambleLength = preamble(false).splitLines.length + 1;
 
     return length > preambleLength ? lines.drop(preambleLength).array : lines.array;
 }


### PR DESCRIPTION
If `--ignoreMacros` is used, then the file is no longer preprocessed (https://github.com/atilaneves/dpp/blob/master/source/dpp/runtime/app.d#L139-L142). However, the preamble will still contain those two `#define`s, so the `.d` file generated will not compile.