### PR TITLE
Do not translate aggregate definition more than once, but translate it when it’s needed.

### DIFF
--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -307,6 +307,12 @@ struct Context {
         rememberType(spelling);
     }
 
+    bool aggregateIsRemembered(in Cursor cursor) @safe pure {
+        import std.algorithm: canFind;
+        const spelling = resolveSpelling(cursor);
+        return _types.canFind(spelling);
+    }
+
     void rememberAggregateParent(in Cursor child, in Cursor parent) @safe pure {
         const parentSpelling = spelling(parent.spelling);
         const childSpelling = resolveSpelling(child);
@@ -375,10 +381,6 @@ struct Context {
 
         return cursorSpelling.isKeyword ? rename(cursorSpelling, this)
                                         : cursorSpelling.idup;
-    }
-
-    bool hasNickname(in Cursor cursor) @safe pure {
-        return cast(bool) (cursor.hash in _nickNames);
     }
 
     private string nickName(in Cursor cursor) @safe pure {

--- a/source/dpp/translation/typedef_.d
+++ b/source/dpp/translation/typedef_.d
@@ -56,7 +56,7 @@ string[] translateNonFunction(in from!"clang".Cursor cursor,
     if(noName && cursor.underlyingType.kind == Type.Kind.Pointer) {
         import dpp.translation.translation: translate;
 
-        auto translation = context.hasNickname(children[0]) ? [] : translate(children[0], context);
+        auto translation = context.aggregateIsRemembered(children[0]) ? [] : translate(children[0], context);
         auto regularTranslation = translateRegular(cursor, context, children);
 
         return translation ~ regularTranslation;

--- a/tests/it/c/compile/typedef_.d
+++ b/tests/it/c/compile/typedef_.d
@@ -203,3 +203,31 @@ unittest {
         shouldCompile("main.d");
     }
 }
+
+
+@("check anonymous struct is defined")
+@safe unittest {
+    with(immutable IncludeSandbox()) {
+        writeFile("hdr.h",
+                `
+                    typedef struct {
+                        void * pad[2];
+                        void * userContext;
+                    } * NDR_SCONTEXT;
+
+                    typedef struct A {
+                        NDR_SCONTEXT k;
+                    };
+                `);
+
+        writeFile("main.dpp",
+                `
+                    #include "hdr.h"
+                    void main() { }
+                `);
+
+        runPreprocessOnly("main.dpp");
+
+        shouldCompile("main.d");
+    }
+}


### PR DESCRIPTION
A nickname for an anonymous struct might be generated without having to translate the anonymous struct as well (e.g. from a FieldDecl, see test). In such a case, `hasNickname` would return `true` in `translateNonFunction`, so the anonymous struct would never get defined, resulting in a compilation error.

`aggregateIsRemembered` is better check because `rememberAggregate` is only called when an aggregate’s definition gets translated, so it’s exactly what we need.