### PR TITLE
Fix compilation with D v2.098 and -dip1000

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-10.15]
         dc:
-          - dmd-2.096.1
-          - dmd-2.095.0
-          - ldc-1.26.0
-          - ldc-1.20.0
+          - dmd-2.098.0
+          - dmd-2.097.2
+          - ldc-1.28.0
+          - ldc-1.27.1
         arch:
           - x86_64
         clang:

--- a/dub.sdl
+++ b/dub.sdl
@@ -29,7 +29,7 @@ buildType "profile-gc" {
 
 
 configuration "executable" {
-    dflags "-dip1000" platform="dmd"
+    dflags "-dip1000"
     mainSourceFile "source/main.d"
 }
 

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -375,14 +375,14 @@ struct Context {
         return spelling(cursor.spelling);
     }
 
-    string spelling(scope const string cursorSpelling) @safe pure {
+    string spelling(const string cursorSpelling) @safe pure {
         import dpp.translation.dlang: rename, isKeyword;
 
         if (cursorSpelling in _aggregateSpelling)
             return _aggregateSpelling[cursorSpelling];
 
         return cursorSpelling.isKeyword ? rename(cursorSpelling, this)
-                                        : cursorSpelling.idup;
+                                        : cursorSpelling;
     }
 
     private string nickName(in Cursor cursor) @safe pure {

--- a/source/dpp/translation/aggregate.d
+++ b/source/dpp/translation/aggregate.d
@@ -483,7 +483,7 @@ void maybeRememberStructs(R)(R types, ref from!"dpp.runtime.context".Context con
         .filter!(a => a.kind == Type.Kind.Pointer && pointeeTypeFor(a).kind == Type.Kind.Record)
         .map!(a => pointeeTypeFor(a));
 
-    void rememberStruct(scope const Type pointeeCanonicalType) @safe {
+    void rememberStruct(const Type pointeeCanonicalType) @safe {
         import dpp.translation.type: translateElaborated;
         import std.array: replace;
         import std.algorithm: canFind;

--- a/source/dpp/translation/type/package.d
+++ b/source/dpp/translation/type/package.d
@@ -454,7 +454,7 @@ private string translateUnexposed(in from!"clang".Type type,
 /**
    Translate possibly problematic C++ spellings
  */
-string translateString(scope const string spelling,
+string translateString(const string spelling,
                        in from!"dpp.runtime.context".Context context)
     @safe nothrow
 {
@@ -496,7 +496,7 @@ string removeDppDecorators(in string spelling) @safe {
 }
 
 // "struct Foo" -> Foo, "union Foo" -> Foo, "enum Foo" -> Foo
-string translateElaborated(const scope string spelling,
+string translateElaborated(const string spelling,
                            ref from!"dpp.runtime.context".Context context) @safe {
     import dpp.runtime.context: Language;
     import std.array: replace;


### PR DESCRIPTION
Current dpp doesn't build with DMD v2.098.0 due to `-dip1000` trouble. I've removed some `scope` from params being forwarded as non-scope args without really digging into things.