### PR TITLE
Fix #303 - fix all literals in a macro

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -101,14 +101,24 @@ private string translateToD(
     @safe
 {
     import dpp.translation.type: translateElaborated;
+    import clang: Token;
+    import std.algorithm: map;
+
     if(isLiteralMacro(tokens)) return fixLiteral(tokens[1]);
     if(tokens.length == 1) return ""; // e.g. `#define FOO`
+
+    auto fixLiteralOrPassThrough(in Token t) {
+        return t.kind == Token.Kind.Literal
+            ? Token(Token.Kind.Literal, fixLiteral(t))
+            : t;
+    }
 
     return tokens
         .fixSizeof(cursor)
         .fixCasts(cursor, context)
         .fixArrow
         .fixNull
+        .map!fixLiteralOrPassThrough
         .toString
         .translateElaborated(context)
         ;

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -1913,3 +1913,24 @@ version(Linux) {
         )
     );
 }
+
+
+@Tags("issue")
+@("303")
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                #include <stdint.h>
+                typedef uint64_t Index;
+                #define INDEX_MAX ((Index) (1ULL << 60))
+            `
+        ),
+        D(
+            q{
+                static assert(INDEX_MAX == (1UL << 60));
+            }
+        )
+    );
+
+}


### PR DESCRIPTION
Before, only a macro consisting of a single literal would be fixed, now all tokens are.