### PR TITLE
ci: use setup-cpp to install llvm

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -49,7 +49,6 @@ jobs:
         uses: aminya/setup-cpp@v1
         with:
           llvm: ${{ matrix.clang }}
-          vcvarsall: ${{ startsWith(matrix.os,'windows') }}
 
       - name: Run tests
         continue-on-error: ${{ contains(matrix.os, 'macos') }}

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Setup Visual Studio Command Prompt - Windows
         if: startsWith(matrix.os,'windows')
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: aminya/setup-cpp@v1
+        with:
+          vcvarsall: true
 
       - name: Setup LLVM
         if: "!${{ steps.cache.outputs.cache-hit }}"

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -45,22 +45,11 @@ jobs:
         with:
           compiler: ${{ matrix.dc }}
 
-      - name: Setup Visual Studio Command Prompt - Windows
-        if: startsWith(matrix.os,'windows')
-        uses: aminya/setup-cpp@v1
-        with:
-          vcvarsall: true
-
-      - name: Setup LLVM
-        if: "!${{ steps.cache.outputs.cache-hit }}"
+      - name: Setup C++
         uses: aminya/setup-cpp@v1
         with:
           llvm: ${{ matrix.clang }}
-
-      - name: Linux - link libclang.so
-        if: contains(matrix.os, 'ubuntu')
-        run: sudo ln -s libclang-${{ matrix.clang }}.so.1 /lib/x86_64-linux-gnu/libclang.so
-        working-directory: ${{ env.LLVM_PATH }}/lib
+          vcvarsall: ${{ startsWith(matrix.os,'windows') }}
 
       - name: Run tests
         continue-on-error: ${{ contains(matrix.os, 'macos') }}

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -37,8 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            C:/Program Files/LLVM
-            ./llvm
+            ~/llvm
           key: cache-os:${{ matrix.os }}-clang:${{ matrix.clang }}
 
       - name: Setup D
@@ -51,31 +50,15 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Setup LLVM
-        uses: KyleMayes/install-llvm-action@v1.4.0
+        if: "!${{ steps.cache.outputs.cache-hit }}"
+        uses: aminya/setup-cpp@v1
         with:
-          version: ${{ matrix.clang }}
-          cached: ${{ steps.cache.outputs.cache-hit }}
+          llvm: ${{ matrix.clang }}
 
       - name: Linux - link libclang.so
         if: contains(matrix.os, 'ubuntu')
         run: sudo ln -s libclang-${{ matrix.clang }}.so.1 /lib/x86_64-linux-gnu/libclang.so
         working-directory: ${{ env.LLVM_PATH }}/lib
-
-      - name: MacOS - Prepare LLVM
-        if: contains(matrix.os, 'macos')
-        run: |
-          LLVM_PATH=${{ env.LLVM_PATH }}
-          LLVM_VERSION=${{ matrix.clang }}
-          # already done inside install-llvm-action
-          # echo "PATH="$LLVM_PATH:$PATH"
-          # echo "LD_LIBRARY_PATH=$LLVM_PATH/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          # echo "DYLD_LIBRARY_PATH=$LLVM_PATH/lib/:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "CPATH=$LLVM_PATH/lib/clang/$LLVM_VERSION/include/" >> $GITHUB_ENV
-          echo "LDFLAGS=-L$LLVM_PATH/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$LLVM_PATH/include" >> $GITHUB_ENV
-          echo "CC=$LLVM_PATH/bin/clang" >> $GITHUB_ENV
-          echo "CXX=$LLVM_PATH/bin/clang++" >> $GITHUB_ENV
 
       - name: Run tests
         continue-on-error: ${{ contains(matrix.os, 'macos') }}

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ After the instructions for your OS (see below), you can use this commands to run
 dub run dpp -- yoursourcefilenamehere.dpp
 ```
 
-Note: for a reproducible and cross-platform build environment, you can run [setup-cpp](https://github.com/aminya/setup-cpp) with `--llvm=11.0.0` and `--vcvarsall=true`. This will set up LLVM 11.0.0 and the proper environment variables.
+Note: for a reproducible and cross-platform build environment, you can run [setup-cpp](https://github.com/aminya/setup-cpp) with `--llvm=11.0.0`. This will set up LLVM 11.0.0 and the proper environment variables.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ After the instructions for your OS (see below), you can use this commands to run
 dub run dpp -- yoursourcefilenamehere.dpp
 ```
 
+Note: to reproduce the environment of dpp's CI, you can run [setup-cpp](https://github.com/aminya/setup-cpp) with `--llvm=11.0.0` and `--vcvarsall=true`. This will set up LLVM 11.0.0 and the proper environment variables.
+
 ### Windows
 
 Install [LLVM](https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/LLVM-12.0.0-win64.exe) into `C:\Program Files\LLVM\`, making sure to tick the "Add LLVM to the system PATH for all users" option.

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ After the instructions for your OS (see below), you can use this commands to run
 dub run dpp -- yoursourcefilenamehere.dpp
 ```
 
-Note: to reproduce the environment of dpp's CI, you can run [setup-cpp](https://github.com/aminya/setup-cpp) with `--llvm=11.0.0` and `--vcvarsall=true`. This will set up LLVM 11.0.0 and the proper environment variables.
+Note: for a reproducible and cross-platform build environment, you can run [setup-cpp](https://github.com/aminya/setup-cpp) with `--llvm=11.0.0` and `--vcvarsall=true`. This will set up LLVM 11.0.0 and the proper environment variables.
 
 ### Windows
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -8,7 +8,6 @@ targetType "executable"
 targetPath "bin"
 targetName "d++"
 dflags "-dip25"
-dflags "--link-internally" platform="ldc"
 
 dependency "libclang" version="~>0.2.0"
 dependency "sumtype"  version="~>0.7.1"

--- a/dub.sdl
+++ b/dub.sdl
@@ -8,6 +8,7 @@ targetType "executable"
 targetPath "bin"
 targetName "d++"
 dflags "-dip25"
+dflags "--link-internally" platform="ldc"
 
 dependency "libclang" version="~>0.2.0"
 dependency "sumtype"  version="~>0.7.1"


### PR DESCRIPTION
This fixes Windows CI failures

Also tested on libclang here:
https://github.com/atilaneves/libclang/pull/34