### PR TITLE
Fix new libclang

### DIFF
--- a/source/dpp/clang/package.d
+++ b/source/dpp/clang/package.d
@@ -113,3 +113,8 @@ from!"clang".Cursor[] baseClasses(in from!"clang".Cursor cursor) @safe nothrow {
         baseCursors.map!baseClasses.joiner,
     ).array;
 }
+
+bool hasAnonymousSpelling(in string spelling) @safe pure nothrow {
+    import std.algorithm : canFind;
+    return spelling.canFind("(anonymous") || spelling.canFind("(unnamed");
+}

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -337,10 +337,11 @@ struct Context {
 
     bool isUnknownStruct(in string name) @safe pure const {
         import std.algorithm: canFind;
+        import dpp.clang: hasAnonymousSpelling;
         return name !in _aggregateDeclarations
             && (name !in _aggregateSpelling
-                || _aggregateSpelling[name] !in _aggregateDeclarations)
-            && !name.canFind("anonymous at");
+            || _aggregateSpelling[name] !in _aggregateDeclarations)
+            && !hasAnonymousSpelling(name);
     }
 
     /**

--- a/source/dpp/translation/type/package.d
+++ b/source/dpp/translation/type/package.d
@@ -562,7 +562,8 @@ private string addModifiers(in from!"clang".Type type, in string translation) @s
 
 bool hasAnonymousSpelling(in from!"clang".Type type) @safe pure nothrow {
     import std.algorithm: canFind;
-    return type.spelling.canFind("(anonymous");
+    // libclang used to use "anonymous" but changed to "unnamed"
+    return type.spelling.canFind("(anonymous") || type.spelling.canFind("(unnamed");
 }
 
 

--- a/source/dpp/translation/type/package.d
+++ b/source/dpp/translation/type/package.d
@@ -561,9 +561,8 @@ private string addModifiers(in from!"clang".Type type, in string translation) @s
 }
 
 bool hasAnonymousSpelling(in from!"clang".Type type) @safe pure nothrow {
-    import std.algorithm: canFind;
-    // libclang used to use "anonymous" but changed to "unnamed"
-    return type.spelling.canFind("(anonymous") || type.spelling.canFind("(unnamed");
+    import dpp.clang: hasAnonymousSpelling;
+    return type.spelling.hasAnonymousSpelling;
 }
 
 

--- a/source/dpp/translation/variable.d
+++ b/source/dpp/translation/variable.d
@@ -12,7 +12,7 @@ string[] translateVariable(in from!"clang".Cursor cursor,
     import dpp.translation.exception: UntranslatableException;
     import dpp.translation.dlang: maybePragma;
     import dpp.translation.translation: translateCursor = translate;
-    import dpp.translation.type: translateType = translate;
+    import dpp.translation.type: translateType = translate, hasAnonymousSpelling;
     import dpp.translation.tokens: translateTokens;
     import clang: Cursor, Type, Token;
     import std.conv: text;
@@ -22,7 +22,7 @@ string[] translateVariable(in from!"clang".Cursor cursor,
 
     string[] ret;
 
-    const isAnonymous = cursor.type.spelling.canFind("(anonymous");
+    const isAnonymous = cursor.type.hasAnonymousSpelling;
     // If the type is anonymous, then we need to define it before we declare
     // ourselves of that type, unless that type is an enum. See #54.
     if(isAnonymous && cursor.type.canonical.declaration.kind != Cursor.Kind.EnumDecl) {

--- a/tests/it/c/compile/struct_.d
+++ b/tests/it/c/compile/struct_.d
@@ -272,7 +272,7 @@ import it;
 
 
 @WIP2
-@("var.anonymous")
+@("var.anonymous.notypedef")
 @safe unittest {
     shouldCompile(
         C(`struct { int i; } var;`),


### PR DESCRIPTION
A new version of libclang has changed the spelling of anonymous types from "anonymous" to "unnamed".