### PR TITLE
Fix #307 - not to resolve include path if possible

### DIFF
--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -160,7 +160,7 @@ private TranslationText translationText(in from!"dpp.runtime.options".Options op
         import dpp.expansion: expand, isCppHeader, getHeaderName;
     import clang.util: getTempFileName;
 
-    import std.algorithm: map, filter;
+    import std.algorithm: map, filter, find, startsWith;
     import std.string: fromStringz;
     import std.path: dirName;
     import std.array: array, join;
@@ -181,7 +181,15 @@ private TranslationText translationText(in from!"dpp.runtime.options".Options op
     () @trusted {
         auto includesFile = File(includesFileName, "w");
         foreach(include; includes) {
-            includesFile.writeln(`#include "`, include, `"`);
+            auto paths = includePaths.find!(p => include.startsWith(p));
+            if (paths.length)
+            {
+                includesFile.writeln(`#include <`, include[paths[0].length+1..$], `>`);
+            }
+            else
+            {
+                includesFile.writeln(`#include "`, include, `"`);
+            }
             if(isCppHeader(options, include)) language = Language.Cpp;
         }
     }();

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -1939,6 +1939,7 @@ version(Linux) {
 @("307")
 @safe unittest {
     with(immutable IncludeSandbox()) {
+        import std.path : pathSeparator;
         import std.process : environment;
         import std.string : join;
 
@@ -1967,7 +1968,7 @@ version(Linux) {
             inSandboxPath("includes/dir1"),
             inSandboxPath("includes/dir2"),
             original_cpath,
-        ].join(":");
+        ].join(pathSeparator);
         scope(exit)
         {
             if (original_cpath == "")


### PR DESCRIPTION
It is caused by the combination of system include paths and the use of `#include_next` directive in the system headers.

In the [example I shown in the issue](https://github.com/atilaneves/dpp/issues/307#issuecomment-1180561484), the dpp first resolves `stdint.h` to `/usr/lib/llvm-10/lib/clang/10.0.0/include/stdint.h` and tries to expand it.
However, `#include_next <stdint.h>` directive in `/usr/lib/llvm-10/lib/clang/10.0.0/include/stdint.h` accidentally includes the same header and failed to include `/usr/include/stdint.h` (it is intended to be included) due to the include guard.

This request fixes this issue by not to resolve the header path if it is in the system paths or specified include paths.

