### PR TITLE
Fix #320 issue

### DIFF
--- a/source/dpp/runtime/options.d
+++ b/source/dpp/runtime/options.d
@@ -118,6 +118,8 @@ struct Options {
 
         if (!noSystemHeaders)
             includePaths = systemPaths ~ includePaths;
+
+        includePaths = includePaths.map!(d => d.stripSeparators).array;
     }
 
     string[] dFileNames() @safe pure const {
@@ -243,4 +245,15 @@ struct Options {
         foreach(i; 0 .. indentation) app ~= " ";
         return app.data;
     }
+}
+
+/// Removes trailing dir separators
+private auto stripSeparators(string dirPath) {
+    import std.algorithm.mutation;
+    import std.conv: to;
+    import std.path;
+
+    char sep = dirSeparator.to!char;
+
+    return dirPath.stripRight(sep).to!string;
 }


### PR DESCRIPTION
Fix #320

upd: It is necessary to explain why it was done through `TemporaryCPATH` - this is because if we try to use for testing CLI arguments like:
```d
runPreprocessOnly("issue320.dpp", "--include-path="~buildPath(sandbox.sandboxPath, "some/include/path");
```
this leads to that directory will be added as last into include dirs list, and first matching directory will always be root of testing sandbox and thus test always passes as good. So here is need this trick for passing include path directly to compiler

