### PR TITLE
Don't try to unclash name if macros aren't emitted

### DIFF
--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -430,7 +430,7 @@ struct Context {
 
     void rememberMacro(in Cursor cursor) @safe pure {
         _macros[cursor.spelling.idup] = true;
-        if(cursor.isMacroFunction)
+        if(cursor.isMacroFunction && options.functionMacros)
             _functionMacroDeclarations[cursor.spelling.idup] = true;
     }
 

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -290,6 +290,31 @@ version(Posix) // because Windows doesn't have signinfo
     );
 }
 
+@Tags("issue", "preprocessor")
+@("22.4")
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                typedef struct { } PyTypeObject;
+                typedef struct { PyTypeObject* ob_type; } PyObject;
+
+                // macro has same name as function
+                inline PyTypeObject* Py_TYPE(PyObject *ob) {
+                    return ob->ob_type;
+                }
+
+                #define Py_TYPE(ob) Py_TYPE((PyObject*)(ob))
+            `
+        ),
+        D(
+            q{
+                void* obj;
+                PyTypeObject* type = Py_TYPE(obj);
+            }
+        ),
+    );
+}
 
 
 @Tags("issue", "collision", "issue24")
@@ -752,7 +777,7 @@ version(Posix) // because Windows doesn't have signinfo
         D(
             q{
                 // it gets renamed
-                func_();
+                func();
             }
         ),
     );

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -291,28 +291,57 @@ version(Posix) // because Windows doesn't have signinfo
 }
 
 @Tags("issue", "preprocessor")
-@("22.4")
+@("22.4.0")
 @safe unittest {
     shouldCompile(
         C(
             `
                 typedef struct { } PyTypeObject;
                 typedef struct { PyTypeObject* ob_type; } PyObject;
+                typedef struct { PyObject* convert; } PyObject2;
 
                 // macro has same name as function
                 inline PyTypeObject* Py_TYPE(PyObject *ob) {
                     return ob->ob_type;
                 }
 
-                #define Py_TYPE(ob) Py_TYPE((PyObject*)(ob))
+                #define Py_TYPE(ob) Py_TYPE(ob->convert)
             `
         ),
         D(
             q{
-                void* obj;
+                PyObject2* obj;
                 PyTypeObject* type = Py_TYPE(obj);
             }
         ),
+    );
+}
+
+@Tags("issue", "preprocessor")
+@("22.4.1")
+@safe unittest {
+    shouldCompile(
+        C(
+            `
+                typedef struct { } PyTypeObject;
+                typedef struct { PyTypeObject* ob_type; } PyObject;
+                typedef struct { PyObject* convert; } PyObject2;
+
+                // macro has same name as function
+                inline PyTypeObject* Py_TYPE(PyObject *ob) {
+                    return ob->ob_type;
+                }
+
+                #define Py_TYPE(ob) Py_TYPE(ob->convert)
+            `
+        ),
+        D(
+            q{
+                PyObject2* obj;
+                PyTypeObject* type = Py_TYPE(obj);
+            }
+        ),
+        ["--function-macros"]
     );
 }
 


### PR DESCRIPTION
No longer emits trailing underscore from function definitions if there
exists a macro with the same name when function macros aren't emitted.

Naming unchanged when function macros are emitted, but the macro definition actually calls its method counter-part now.