### PR TITLE
simplify generated D code for literal macros

### DIFF
--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -264,22 +264,18 @@ private auto fixNull(R)(R tokens)
         ;
 }
 
-version(Windows)
 private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
     import std.algorithm: endsWith;
+    import std.string: representation;
 
-    if(str.endsWith("i64"))
+    if(str.representation.endsWith("i64".representation, "I64".representation))
         return str[0 .. $-3] ~ "L";
-    else if(str.endsWith("i32"))
+    else if(str.representation.endsWith("i32".representation, "I32".representation))
         return str[0 .. $-3];
-    else if(str.endsWith("i16"))
+    else if(str.representation.endsWith("i16".representation, "I16".representation))
         return str[0 .. $-3];
-    else if(str.endsWith("i8"))
-        return str[0 .. $-3];
-    return str;
-}
-else
-private string fixMicrosoftSuffixes(in string str) @safe pure nothrow {
+    else if(str.representation.endsWith("i8".representation, "I8".representation))
+        return str[0 .. $-2];
     return str;
 }
 

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -1884,6 +1884,10 @@ version(Linux) {
                   #define V3 3.4
                   #define V4 3.4f
                   #define V5 nonExistantVariable
+                  #define V6 0x40000000000UI64
+                  #define V7 0x40000000000ULL
+                  #define V8 0x40000000000LL
+                  #define V9 9i8
                   `);
         writeFile("issue263.dpp",
                   `
@@ -1893,6 +1897,10 @@ version(Linux) {
                    enum V2D = V2;
                    enum V3D = V3;
                    enum V4D = V4;
+                   enum V6D = V6;
+                   enum V7D = V7;
+                   enum V8D = V8;
+                   enum V9D = V9;
                   `);
         runPreprocessOnly("issue263.dpp");
         // we check if there is whitespace before the enum, because just the
@@ -1903,6 +1911,10 @@ version(Linux) {
         fileShouldContain("issue263.d", "    enum V2 = \"hello\";");
         fileShouldContain("issue263.d", "    enum V3 = 3.4;");
         fileShouldContain("issue263.d", "    enum V4 = 3.4f;");
+        fileShouldContain("issue263.d", "    enum V6 = 0x40000000000UL;");
+        fileShouldContain("issue263.d", "    enum V7 = 0x40000000000LU;");
+        fileShouldContain("issue263.d", "    enum V8 = 0x40000000000L;");
+        fileShouldContain("issue263.d", "    enum V9 = 9;");
 
         writeFile("app.d",
                   q{
@@ -1915,6 +1927,10 @@ version(Linux) {
                       double v3 = V3; enum v3d = V3D;
                       float v4 = V4; float v4d = V4D;
                       static assert(!is(typeof(V5)));
+                      ulong v6 = V6; ulong v6d = V6D;
+                      ulong v7 = V7; ulong v7d = V7D;
+                      long v8 = V8; long v8d = V8D;
+                      byte v9 = V9; byte v9d = V9D;
                   }
                   });
 

--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -1873,6 +1873,56 @@ version(Linux) {
 }
 
 
+@Tags("issue")
+@("263")
+@safe unittest {
+    with(immutable IncludeSandbox()) {
+        writeFile("issue263.h",
+                  `
+                  #define V1 1
+                  #define V2 "hello"
+                  #define V3 3.4
+                  #define V4 3.4f
+                  #define V5 nonExistantVariable
+                  `);
+        writeFile("issue263.dpp",
+                  `
+                   #include "issue263.h"
+
+                   enum V1D = V1;
+                   enum V2D = V2;
+                   enum V3D = V3;
+                   enum V4D = V4;
+                  `);
+        runPreprocessOnly("issue263.dpp");
+        // we check if there is whitespace before the enum, because just the
+        // enum definition alone would always match, since it's written in the
+        // mixin string variable as well. We don't check for line ending due to
+        // possible LF/CRLF differences.h
+        fileShouldContain("issue263.d", "    enum V1 = 1;");
+        fileShouldContain("issue263.d", "    enum V2 = \"hello\";");
+        fileShouldContain("issue263.d", "    enum V3 = 3.4;");
+        fileShouldContain("issue263.d", "    enum V4 = 3.4f;");
+
+        writeFile("app.d",
+                  q{
+                  import issue263;
+
+                  void main()
+                  {
+                      int v1 = V1; int v1d = V1D;
+                      string v2 = V2; string v2d = V2D;
+                      double v3 = V3; enum v3d = V3D;
+                      float v4 = V4; float v4d = V4D;
+                      static assert(!is(typeof(V5)));
+                  }
+                  });
+
+        shouldCompile("app.d");
+    }
+}
+
+
 @ShouldFail
 @Tags("issue")
 @("269")


### PR DESCRIPTION
fix #263

single token string and integer literals are emitted as-is with this, without running through the is(typeof()) check.

Since all integers and strings should be representable in D, they should be fine to be included directly after translation.