### PR TITLE
wrap #defines accessing runtime info into methods

### DIFF
--- a/tests/it/issues.d
+++ b/tests/it/issues.d
@@ -2205,6 +2205,8 @@ version(Windows)
                       extern __declspec(dllimport) long ExportData;
 
                       __declspec(dllimport) long* CAddress();
+
+                      #define CAddressMacro (&ExportData)
                   `);
         writeFile("hdr.c",
                   `
@@ -2225,7 +2227,10 @@ version(Windows)
 
                       void main()
                       {
+                          assert(CAddress() !is null);
                           assert(CAddress() is &ExportData);
+                          assert(CAddressMacro !is null);
+                          assert(CAddressMacro is &ExportData);
                       }
                   });
 


### PR DESCRIPTION
Only a heuristic, but better wrap more than less here, CTFE will cover
the cases when users need compile time values anyway.

Depends on #336 