### PR TITLE
Treat .c files as C headers

### DIFF
--- a/source/dpp/expansion/package.d
+++ b/source/dpp/expansion/package.d
@@ -295,7 +295,9 @@ from!"clang".Cursor mergeLeaves(from!"clang".Cursor lhs, from!"clang".Cursor rhs
 bool isCppHeader(in from!"dpp.runtime.options".Options options, in string headerFileName) @safe pure {
     import std.path: extension;
     if(options.parseAsCpp) return true;
-    return headerFileName.extension != ".h";
+    return
+        headerFileName.extension != ".h" &&
+        headerFileName.extension != ".c";
 }
 
 


### PR DESCRIPTION
(Rare but useful case)

Standards isn't prohibit directive like `#include "c_file.c"`. But if included file is `.c` or `.i` (preprocessed file) it will allways be treated as C++ header by dpp. 

I planning to use this change to ease creating bindings by adding ` -save-temps` flag into (almost any) C build environment and then processing obtained preprocessed files by dpp - so it helps to avoid of collecting of C compilation flags and passing all of them into dpp